### PR TITLE
Correct value for resource value "cluster_ca_certificate"

### DIFF
--- a/minikube/resource_cluster.go
+++ b/minikube/resource_cluster.go
@@ -188,7 +188,7 @@ func getClusterOutputs(kc *kubeconfig.Settings) (string, string, string, string,
 		return "", "", "", "", err
 	}
 
-	ca, err := state_utils.ReadContents(kc.ClientCertificate)
+	ca, err := state_utils.ReadContents(kc.CertificateAuthority)
 	if err != nil {
 		return "", "", "", "", err
 	}


### PR DESCRIPTION
Hi,

seems variables were interchanged.
Result was wrong value for resource result "cluster_ca_certificate".


