### PR TITLE
Allow computed fields to have defaults

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,6 +21,17 @@
           "args": [
               "-debug",
           ]
+      },
+      {
+          "name": "Debug Generator",
+          "type": "go",
+          "request": "launch",
+          "mode": "debug",
+          "program": "${workspaceFolder}/generate/main.go",
+          "args": [
+              "-target",
+              "./minikube/schema_cluster.go",
+          ]
       }
   ]
 }

--- a/minikube/generator/schema_builder.go
+++ b/minikube/generator/schema_builder.go
@@ -40,10 +40,6 @@ var computedFields []string = []string{
 	"nfs_share",
 	"ports",
 	"registry_mirror",
-	"client_key",
-	"client_certificate",
-	"cluster_ca_certificate",
-	"host",
 }
 
 type SchemaOverride struct {
@@ -318,16 +314,16 @@ var (
 	body := ""
 	for _, entry := range entries {
 		extraParams := ""
-		if !contains(computedFields, entry.Parameter) {
-			extraParams = `
-			Optional:			true,
-			ForceNew:			true,
-			`
-		} else {
+		if contains(computedFields, entry.Parameter) {
 			extraParams = `
 			Computed:			true,
 			`
 		}
+
+		extraParams += `
+			Optional:			true,
+			ForceNew:			true,
+			`
 
 		if entry.Type == Array {
 			extraParams += fmt.Sprintf(`

--- a/minikube/generator/schema_builder_test.go
+++ b/minikube/generator/schema_builder_test.go
@@ -284,12 +284,12 @@ func GetClusterSchema() map[string]*schema.Schema {
 	`, schema)
 }
 
-func TestOutputProperty(t *testing.T) {
+func TestComputedProperty(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockMinikube := NewMockMinikubeBinary(ctrl)
 	mockMinikube.EXPECT().GetVersion(gomock.Any()).Return("Version 999", nil)
 	mockMinikube.EXPECT().GetStartHelpText(gomock.Any()).Return(`
---host=123:
+--insecure-registry=123:
 	I am a great test description
 
 	`, nil)
@@ -297,11 +297,14 @@ func TestOutputProperty(t *testing.T) {
 	schema, err := builder.Build()
 	assert.NoError(t, err)
 	assert.Equal(t, header+`
-		"host": {
+		"insecure_registry": {
 			Type:					schema.TypeInt,
 			Description:	"I am a great test description",
 			
 			Computed:			true,
+			
+			Optional:			true,
+			ForceNew:			true,
 			
 			Default:	123,
 		},

--- a/minikube/resource_cluster_test.go
+++ b/minikube/resource_cluster_test.go
@@ -264,6 +264,12 @@ func testAcceptanceClusterConfig(driver string, clusterName string) string {
 		cluster_name = "%s"
 		cpus = 2 
 		memory = "6000mb"
+
+		addons = [
+			"dashboard",
+			"default-storageclass",
+			"ingress"
+		]
 	}
 	`, driver, clusterName)
 }

--- a/minikube/schema_cluster.go
+++ b/minikube/schema_cluster.go
@@ -59,6 +59,9 @@ var (
 			
 			Computed:			true,
 			
+			Optional:			true,
+			ForceNew:			true,
+			
 			Elem: &schema.Schema{
 				Type:	schema.TypeString,
 			},
@@ -70,6 +73,9 @@ var (
 			Description:	"A set of apiserver IP Addresses which are used in the generated certificate for kubernetes.  This can be used if you want to make the apiserver available from outside the machine",
 			
 			Computed:			true,
+			
+			Optional:			true,
+			ForceNew:			true,
 			
 			Elem: &schema.Schema{
 				Type:	schema.TypeString,
@@ -92,6 +98,9 @@ var (
 			Description:	"A set of apiserver names which are used in the generated certificate for kubernetes.  This can be used if you want to make the apiserver available from outside the machine",
 			
 			Computed:			true,
+			
+			Optional:			true,
+			ForceNew:			true,
 			
 			Elem: &schema.Schema{
 				Type:	schema.TypeString,
@@ -441,6 +450,9 @@ var (
 			
 			Computed:			true,
 			
+			Optional:			true,
+			ForceNew:			true,
+			
 			Elem: &schema.Schema{
 				Type:	schema.TypeString,
 			},
@@ -503,6 +515,9 @@ var (
 			
 			Computed:			true,
 			
+			Optional:			true,
+			ForceNew:			true,
+			
 			Elem: &schema.Schema{
 				Type:	schema.TypeString,
 			},
@@ -534,6 +549,9 @@ var (
 			Description:	"Locations to fetch the minikube ISO from.",
 			
 			Computed:			true,
+			
+			Optional:			true,
+			ForceNew:			true,
 			
 			Elem: &schema.Schema{
 				Type:	schema.TypeString,
@@ -801,6 +819,9 @@ var (
 			
 			Computed:			true,
 			
+			Optional:			true,
+			ForceNew:			true,
+			
 			Elem: &schema.Schema{
 				Type:	schema.TypeString,
 			},
@@ -843,6 +864,9 @@ var (
 			
 			Computed:			true,
 			
+			Optional:			true,
+			ForceNew:			true,
+			
 			Elem: &schema.Schema{
 				Type:	schema.TypeString,
 			},
@@ -874,6 +898,9 @@ var (
 			Description:	"Registry mirrors to pass to the Docker daemon",
 			
 			Computed:			true,
+			
+			Optional:			true,
+			ForceNew:			true,
 			
 			Elem: &schema.Schema{
 				Type:	schema.TypeString,


### PR DESCRIPTION
Blocker that I noticed when testing 0.1.0-alpha. Computed fields in minikube can always be overridden 