### PR TITLE
refactor addons into an updatable property

### DIFF
--- a/hack/main.go
+++ b/hack/main.go
@@ -108,7 +108,7 @@ func main() {
 	}
 
 	minikubeClient := service.NewMinikubeClient(
-		service.MinikubeClientArgs{
+		service.MinikubeClientConfig{
 			ClusterConfig:   cc,
 			ClusterName:     "terraform-provider-minikube-acc",
 			Addons:          []string{},

--- a/minikube/generator/schema_builder.go
+++ b/minikube/generator/schema_builder.go
@@ -31,7 +31,6 @@ func (m *MinikubeHostBinary) GetStartHelpText(ctx context.Context) (string, erro
 }
 
 var computedFields []string = []string{
-	"addons",
 	"apiserver_ips",
 	"apiserver_names",
 	"hyperkit_vsock_ports",
@@ -49,6 +48,9 @@ type SchemaOverride struct {
 	DefaultFunc string
 }
 
+var updateFields = []string{
+	"addons",
+}
 var schemaOverrides map[string]SchemaOverride = map[string]SchemaOverride{
 	"memory": {
 		Default:     "4000mb",
@@ -320,10 +322,16 @@ var (
 			`
 		}
 
-		extraParams += `
+		if !contains(updateFields, entry.Parameter) {
+			extraParams += `
 			Optional:			true,
 			ForceNew:			true,
 			`
+		} else {
+			extraParams += `
+			Optional:			true,
+			`
+		}
 
 		if entry.Type == Array {
 			extraParams += fmt.Sprintf(`

--- a/minikube/generator/schema_builder_test.go
+++ b/minikube/generator/schema_builder_test.go
@@ -350,6 +350,40 @@ func GetClusterSchema() map[string]*schema.Schema {
 	`, schema)
 }
 
+func TestUpdateField(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockMinikube := NewMockMinikubeBinary(ctrl)
+	mockMinikube.EXPECT().GetVersion(gomock.Any()).Return("Version 999", nil)
+	mockMinikube.EXPECT().GetStartHelpText(gomock.Any()).Return(`
+--addons=[]:
+	I am a great test description
+
+	`, nil)
+	builder := NewSchemaBuilder("fake.go", mockMinikube)
+	schema, err := builder.Build()
+	assert.NoError(t, err)
+	assert.Equal(t, header+`
+		"addons": {
+			Type:					schema.TypeList,
+			Description:	"I am a great test description",
+			
+			Optional:			true,
+			
+			Elem: &schema.Schema{
+				Type:	schema.TypeString,
+			},
+			
+		},
+	
+	}
+)
+
+func GetClusterSchema() map[string]*schema.Schema {
+	return clusterSchema
+}
+	`, schema)
+}
+
 func TestDefaultFuncOverride(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockMinikube := NewMockMinikubeBinary(ctrl)

--- a/minikube/resource_cluster.go
+++ b/minikube/resource_cluster.go
@@ -85,7 +85,10 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, m interf
 			Nodes:           config.Nodes,
 		})
 
-		client.ApplyAddons(newAddonStrings)
+		err = client.ApplyAddons(newAddonStrings)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 
 		sort.Strings(newAddonStrings) //to ensure consistency with TF state
 

--- a/minikube/schema_cluster.go
+++ b/minikube/schema_cluster.go
@@ -57,10 +57,7 @@ var (
 			Type:					schema.TypeList,
 			Description:	"Enable addons. see `minikube addons list` for a list of valid addon names.",
 			
-			Computed:			true,
-			
 			Optional:			true,
-			ForceNew:			true,
 			
 			Elem: &schema.Schema{
 				Type:	schema.TypeString,

--- a/minikube/service/minikube_client.go
+++ b/minikube/service/minikube_client.go
@@ -98,7 +98,7 @@ func init() {
 
 }
 
-// SetConfig provides an injection point for setting the cluster config
+// SetConfig sets the clients configuration
 func (e *MinikubeClient) SetConfig(args MinikubeClientConfig) {
 	e.clusterConfig = args.ClusterConfig
 	e.isoUrls = args.IsoUrls
@@ -108,6 +108,7 @@ func (e *MinikubeClient) SetConfig(args MinikubeClientConfig) {
 	e.nodes = args.Nodes
 }
 
+// GetConfig retrieves the current clients configuration
 func (e *MinikubeClient) GetConfig() MinikubeClientConfig {
 	return MinikubeClientConfig{
 		ClusterConfig:   e.clusterConfig,

--- a/minikube/service/minikube_client.go
+++ b/minikube/service/minikube_client.go
@@ -187,6 +187,7 @@ func (e *MinikubeClient) Start() (*kubeconfig.Settings, error) {
 
 func (e *MinikubeClient) ApplyAddons(addons []string) error {
 
+	viper.Set(config.ProfileName, e.clusterName)
 	addonsToDelete := diff(e.addons, addons)
 	err := e.setAddons(addonsToDelete, false)
 	if err != nil {

--- a/minikube/service/minikube_client_test.go
+++ b/minikube/service/minikube_client_test.go
@@ -21,6 +21,7 @@ func TestMinikubeClient_Start(t *testing.T) {
 		nRunner         Node
 		dLoader         Downloader
 		nodes           int
+		tfCreationLock  sync.Mutex
 	}
 
 	ctrl := gomock.NewController(t)
@@ -44,6 +45,7 @@ func TestMinikubeClient_Start(t *testing.T) {
 				nRunner:         getNodeSuccess(ctrl),
 				dLoader:         getDownloadSuccess(ctrl),
 				nodes:           1,
+				tfCreationLock:  sync.Mutex{},
 			},
 			wantErr: false,
 		},
@@ -63,6 +65,7 @@ func TestMinikubeClient_Start(t *testing.T) {
 				nRunner:         getNodeSuccess(ctrl),
 				dLoader:         getDownloadSuccess(ctrl),
 				nodes:           1,
+				tfCreationLock:  sync.Mutex{},
 			},
 			wantErr: false,
 		},
@@ -82,6 +85,7 @@ func TestMinikubeClient_Start(t *testing.T) {
 				nRunner:         getMultipleNodesSuccess(ctrl, 3),
 				dLoader:         getDownloadSuccess(ctrl),
 				nodes:           3,
+				tfCreationLock:  sync.Mutex{},
 			},
 			wantErr: false,
 		},
@@ -101,6 +105,7 @@ func TestMinikubeClient_Start(t *testing.T) {
 				nRunner:         getMultipleNodesFailure(ctrl),
 				dLoader:         getDownloadSuccess(ctrl),
 				nodes:           3,
+				tfCreationLock:  sync.Mutex{},
 			},
 			wantErr: true,
 		},
@@ -118,6 +123,7 @@ func TestMinikubeClient_Start(t *testing.T) {
 				nRunner:         nil,
 				dLoader:         getDownloadFailure(ctrl),
 				nodes:           1,
+				tfCreationLock:  sync.Mutex{},
 			},
 			wantErr: true,
 		},
@@ -135,6 +141,7 @@ func TestMinikubeClient_Start(t *testing.T) {
 				nRunner:         nil,
 				dLoader:         getTarballFailure(ctrl),
 				nodes:           1,
+				tfCreationLock:  sync.Mutex{},
 			},
 			wantErr: true,
 		},
@@ -152,6 +159,7 @@ func TestMinikubeClient_Start(t *testing.T) {
 				nRunner:         getProvisionerFailure(ctrl),
 				dLoader:         getDownloadSuccess(ctrl),
 				nodes:           1,
+				tfCreationLock:  sync.Mutex{},
 			},
 			wantErr: true,
 		},
@@ -169,6 +177,7 @@ func TestMinikubeClient_Start(t *testing.T) {
 				nRunner:         getStartFailure(ctrl),
 				dLoader:         getDownloadSuccess(ctrl),
 				nodes:           1,
+				tfCreationLock:  sync.Mutex{},
 			},
 			wantErr: true,
 		},

--- a/minikube/service/minikube_client_test.go
+++ b/minikube/service/minikube_client_test.go
@@ -398,6 +398,65 @@ func TestMinikubeClient_SetDependencies(t *testing.T) {
 	}
 }
 
+func TestMinikubeClient_GetConfig(t *testing.T) {
+	type fields struct {
+		clusterConfig   config.ClusterConfig
+		clusterName     string
+		addons          []string
+		isoUrls         []string
+		deleteOnFailure bool
+		nodes           int
+		TfCreationLock  *sync.Mutex
+		K8sVersion      string
+		nRunner         Node
+		dLoader         Downloader
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   MinikubeClientConfig
+	}{
+		{
+			name: "Retrieves client config",
+			fields: fields{
+				clusterConfig:   config.ClusterConfig{},
+				isoUrls:         []string{"url1", "url2"},
+				clusterName:     "abc",
+				addons:          []string{"addon1", "addon2"},
+				deleteOnFailure: false,
+				nodes:           1,
+			},
+			want: MinikubeClientConfig{
+				ClusterConfig:   config.ClusterConfig{},
+				IsoUrls:         []string{"url1", "url2"},
+				ClusterName:     "abc",
+				Addons:          []string{"addon1", "addon2"},
+				DeleteOnFailure: false,
+				Nodes:           1,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &MinikubeClient{
+				clusterConfig:   tt.fields.clusterConfig,
+				clusterName:     tt.fields.clusterName,
+				addons:          tt.fields.addons,
+				isoUrls:         tt.fields.isoUrls,
+				deleteOnFailure: tt.fields.deleteOnFailure,
+				nodes:           tt.fields.nodes,
+				TfCreationLock:  tt.fields.TfCreationLock,
+				K8sVersion:      tt.fields.K8sVersion,
+				nRunner:         tt.fields.nRunner,
+				dLoader:         tt.fields.dLoader,
+			}
+			if got := e.GetConfig(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("MinikubeClient.GetConfig() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMinikubeClient_DisableAddons(t *testing.T) {
 	type fields struct {
 		clusterConfig   config.ClusterConfig

--- a/minikube/service/minikube_client_test.go
+++ b/minikube/service/minikube_client_test.go
@@ -457,7 +457,7 @@ func TestMinikubeClient_GetConfig(t *testing.T) {
 	}
 }
 
-func TestMinikubeClient_DisableAddons(t *testing.T) {
+func TestMinikubeClient_ApplyAddons(t *testing.T) {
 	type fields struct {
 		clusterConfig   config.ClusterConfig
 		clusterName     string

--- a/minikube/service/minikube_client_test.go
+++ b/minikube/service/minikube_client_test.go
@@ -483,8 +483,9 @@ func TestMinikubeClient_ApplyAddons(t *testing.T) {
 		{
 			name: "Should remove existing addons",
 			fields: fields{
-				clusterName: "cluster",
-				addons:      []string{"feature1", "feature2"},
+				clusterName:    "cluster",
+				addons:         []string{"feature1", "feature2"},
+				TfCreationLock: &sync.Mutex{},
 			},
 			args: args{
 				addons: []string{"feature1"},
@@ -495,8 +496,9 @@ func TestMinikubeClient_ApplyAddons(t *testing.T) {
 		{
 			name: "Should add new addons",
 			fields: fields{
-				clusterName: "cluster",
-				addons:      []string{"feature1", "feature2"},
+				clusterName:    "cluster",
+				addons:         []string{"feature1", "feature2"},
+				TfCreationLock: &sync.Mutex{},
 			},
 			args: args{
 				addons: []string{"feature1", "feature2", "feature3"},
@@ -507,8 +509,9 @@ func TestMinikubeClient_ApplyAddons(t *testing.T) {
 		{
 			name: "Should remove and add addons",
 			fields: fields{
-				clusterName: "cluster",
-				addons:      []string{"feature1", "feature2"},
+				clusterName:    "cluster",
+				addons:         []string{"feature1", "feature2"},
+				TfCreationLock: &sync.Mutex{},
 			},
 			args: args{
 				addons: []string{"feature3"},

--- a/minikube/service/minikube_cluster.go
+++ b/minikube/service/minikube_cluster.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/machine/libmachine"
 	"github.com/docker/machine/libmachine/host"
 	delete "k8s.io/minikube/cmd/minikube/cmd"
+	minikubeAddons "k8s.io/minikube/pkg/addons"
 	"k8s.io/minikube/pkg/minikube/command"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/exit"
@@ -24,6 +25,7 @@ type Node interface {
 	Delete(cc config.ClusterConfig, name string) (*config.Node, error)
 	Get(name string) mustload.ClusterController
 	Add(cc *config.ClusterConfig, starter node.Starter) error
+	SetAddon(name string, addon string, value string) error
 }
 
 type MinikubeCluster struct {
@@ -86,6 +88,10 @@ func (m *MinikubeCluster) Delete(cc config.ClusterConfig, name string) (*config.
 	}
 
 	return nil, err
+}
+
+func (m *MinikubeCluster) SetAddon(name string, addon string, value string) error {
+	return minikubeAddons.SetAndSave(name, addon, value)
 }
 
 func (m *MinikubeCluster) Get(name string) mustload.ClusterController {

--- a/minikube/service/mock_minikube_client.go
+++ b/minikube/service/mock_minikube_client.go
@@ -35,6 +35,20 @@ func (m *MockClusterClient) EXPECT() *MockClusterClientMockRecorder {
 	return m.recorder
 }
 
+// ApplyAddons mocks base method.
+func (m *MockClusterClient) ApplyAddons(addons []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyAddons", addons)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyAddons indicates an expected call of ApplyAddons.
+func (mr *MockClusterClientMockRecorder) ApplyAddons(addons interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyAddons", reflect.TypeOf((*MockClusterClient)(nil).ApplyAddons), addons)
+}
+
 // Delete mocks base method.
 func (m *MockClusterClient) Delete() error {
 	m.ctrl.T.Helper()
@@ -63,6 +77,20 @@ func (mr *MockClusterClientMockRecorder) GetClusterConfig() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterConfig", reflect.TypeOf((*MockClusterClient)(nil).GetClusterConfig))
 }
 
+// GetConfig mocks base method.
+func (m *MockClusterClient) GetConfig() MinikubeClientConfig {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetConfig")
+	ret0, _ := ret[0].(MinikubeClientConfig)
+	return ret0
+}
+
+// GetConfig indicates an expected call of GetConfig.
+func (mr *MockClusterClientMockRecorder) GetConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfig", reflect.TypeOf((*MockClusterClient)(nil).GetConfig))
+}
+
 // GetK8sVersion mocks base method.
 func (m *MockClusterClient) GetK8sVersion() string {
 	m.ctrl.T.Helper()
@@ -78,7 +106,7 @@ func (mr *MockClusterClientMockRecorder) GetK8sVersion() *gomock.Call {
 }
 
 // SetConfig mocks base method.
-func (m *MockClusterClient) SetConfig(args MinikubeClientArgs) {
+func (m *MockClusterClient) SetConfig(args MinikubeClientConfig) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetConfig", args)
 }

--- a/minikube/service/mock_minikube_node.go
+++ b/minikube/service/mock_minikube_node.go
@@ -101,6 +101,20 @@ func (mr *MockNodeMockRecorder) Provision(cc, n, apiServer, delOnFail interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Provision", reflect.TypeOf((*MockNode)(nil).Provision), cc, n, apiServer, delOnFail)
 }
 
+// SetAddon mocks base method.
+func (m *MockNode) SetAddon(name, addon, value string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetAddon", name, addon, value)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetAddon indicates an expected call of SetAddon.
+func (mr *MockNodeMockRecorder) SetAddon(name, addon, value interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAddon", reflect.TypeOf((*MockNode)(nil).SetAddon), name, addon, value)
+}
+
 // Start mocks base method.
 func (m *MockNode) Start(starter node.Starter, apiServer bool) (*kubeconfig.Settings, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This PR attempts to address issue https://github.com/scott-the-programmer/terraform-provider-minikube/issues https://github.com/scott-the-programmer/terraform-provider-minikube/issues/53 where a simple update to the `addons` property causes a cluster recreation.

Minikube exposes this via [addons.SetAndSave](https://github.com/kubernetes/minikube/blob/ad6e665a54ca733f720c4af45ec8d1a923205263/pkg/addons/addons.go#L173). This means we can diff between the old / new terraform args and have this reflected


** Note: Still largely a draft. Haven't really tested this yet