### PR TITLE
provide helpful error when applying against a stopped cluster

### DIFF
--- a/hack/main.go
+++ b/hack/main.go
@@ -48,6 +48,7 @@ func main() {
 	}
 
 	mountString, _ := schema["mount_string"].DefaultFunc()
+
 	cc := config.ClusterConfig{
 		Name:                    "terraform-provider-minikube-acc",
 		KeepContext:             schema["keep_context"].Default.(bool),
@@ -109,6 +110,11 @@ func main() {
 		MultiNodeRequested: false,
 	}
 
+	cluster, err := service.NewMinikubeCluster()
+	if err != nil {
+		println(err.Error())
+		os.Exit(1)
+	}
 	minikubeClient := service.NewMinikubeClient(
 		service.MinikubeClientConfig{
 			ClusterConfig:   cc,
@@ -117,7 +123,7 @@ func main() {
 			IsoUrls:         []string{"https://github.com/kubernetes/minikube/releases/download/v1.26.1/minikube-v1.26.1-amd64.iso"},
 			DeleteOnFailure: true},
 		service.MinikubeClientDeps{
-			Node:       service.NewMinikubeCluster(),
+			Node:       cluster,
 			Downloader: service.NewMinikubeDownloader(),
 		})
 

--- a/minikube/resource_cluster.go
+++ b/minikube/resource_cluster.go
@@ -370,12 +370,13 @@ func initialiseMinikubeClient(d *schema.ResourceData, m interface{}) (service.Cl
 		Nodes:           d.Get("nodes").(int),
 	})
 
+	cluster, err := service.NewMinikubeCluster()
 	clusterClient.SetDependencies(service.MinikubeClientDeps{
-		Node:       service.NewMinikubeCluster(),
+		Node:       cluster,
 		Downloader: service.NewMinikubeDownloader(),
 	})
 
-	return clusterClient, nil
+	return clusterClient, err
 }
 
 func getAddons(addons interface{}) []string {

--- a/minikube/service/minikube_client.go
+++ b/minikube/service/minikube_client.go
@@ -148,6 +148,15 @@ func (e *MinikubeClient) Start() (*kubeconfig.Settings, error) {
 
 	e.clusterConfig.MinikubeISO = url
 
+	status, err := e.nRunner.Status(e.clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	if status == "Stopped" {
+		return nil, fmt.Errorf("%s is currently stopped. Either start the cluster via minikube or try recreating it", e.clusterName)
+	}
+
 	mRunner, preExists, mAPI, host, err := e.nRunner.Provision(&e.clusterConfig, &e.clusterConfig.Nodes[0], true, true)
 	if err != nil {
 		return nil, err

--- a/minikube/service/minikube_client_test.go
+++ b/minikube/service/minikube_client_test.go
@@ -201,6 +201,24 @@ func TestMinikubeClient_Start(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "Status Failure",
+			fields: fields{
+				clusterConfig: config.ClusterConfig{
+					Nodes: []config.Node{
+						{},
+					},
+				},
+				addons:          []string{},
+				isoUrls:         []string{},
+				deleteOnFailure: true,
+				nRunner:         getStatusFailure(ctrl),
+				dLoader:         getDownloadSuccess(ctrl),
+				nodes:           1,
+				tfCreationLock:  sync.Mutex{},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -682,6 +700,16 @@ func getStoppedCluster(ctrl *gomock.Controller) Cluster {
 	nRunnerStatusStopped.EXPECT().
 		Status(gomock.Any()).
 		Return("Stopped", nil)
+
+	return nRunnerStatusStopped
+}
+
+func getStatusFailure(ctrl *gomock.Controller) Cluster {
+	nRunnerStatusStopped := NewMockCluster(ctrl)
+
+	nRunnerStatusStopped.EXPECT().
+		Status(gomock.Any()).
+		Return("", errors.New("oh nooo"))
 
 	return nRunnerStatusStopped
 }

--- a/minikube/service/minikube_client_test.go
+++ b/minikube/service/minikube_client_test.go
@@ -183,6 +183,24 @@ func TestMinikubeClient_Start(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "Stopped Cluster Failure",
+			fields: fields{
+				clusterConfig: config.ClusterConfig{
+					Nodes: []config.Node{
+						{},
+					},
+				},
+				addons:          []string{},
+				isoUrls:         []string{},
+				deleteOnFailure: true,
+				nRunner:         getStoppedCluster(ctrl),
+				dLoader:         getDownloadSuccess(ctrl),
+				nodes:           1,
+				tfCreationLock:  sync.Mutex{},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -633,6 +651,10 @@ func getProvisionerFailure(ctrl *gomock.Controller) Cluster {
 		Provision(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil, false, nil, nil, errors.New("provision error"))
 
+	nRunnerProvisionFailure.EXPECT().
+		Status(gomock.Any()).
+		Return("", nil)
+
 	return nRunnerProvisionFailure
 }
 
@@ -647,7 +669,21 @@ func getStartFailure(ctrl *gomock.Controller) Cluster {
 		Start(gomock.Any(), true).
 		Return(nil, errors.New("start error"))
 
+	nRunnerStartFailure.EXPECT().
+		Status(gomock.Any()).
+		Return("", nil)
+
 	return nRunnerStartFailure
+}
+
+func getStoppedCluster(ctrl *gomock.Controller) Cluster {
+	nRunnerStatusStopped := NewMockCluster(ctrl)
+
+	nRunnerStatusStopped.EXPECT().
+		Status(gomock.Any()).
+		Return("Stopped", nil)
+
+	return nRunnerStatusStopped
 }
 
 func getDownloadFailure(ctrl *gomock.Controller) Downloader {
@@ -685,6 +721,10 @@ func getNodeSuccess(ctrl *gomock.Controller) Cluster {
 		Start(gomock.Any(), true).
 		Return(nil, nil)
 
+	nRunnerSuccess.EXPECT().
+		Status(gomock.Any()).
+		Return("", nil)
+
 	return nRunnerSuccess
 }
 
@@ -704,6 +744,10 @@ func getMultipleNodesSuccess(ctrl *gomock.Controller, n int) Cluster {
 		Return(nil).
 		Times(n - 1)
 
+	nRunnerSuccess.EXPECT().
+		Status(gomock.Any()).
+		Return("", nil)
+
 	return nRunnerSuccess
 }
 
@@ -721,6 +765,10 @@ func getMultipleNodesFailure(ctrl *gomock.Controller) Cluster {
 	nRunnerSuccess.EXPECT().
 		Add(gomock.Any(), gomock.Any()).
 		Return(errors.New("error adding node"))
+
+	nRunnerSuccess.EXPECT().
+		Status(gomock.Any()).
+		Return("", nil)
 
 	return nRunnerSuccess
 }

--- a/minikube/service/mock_minikube_cluster.go
+++ b/minikube/service/mock_minikube_cluster.go
@@ -129,3 +129,18 @@ func (mr *MockClusterMockRecorder) Start(starter, apiServer interface{}) *gomock
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockCluster)(nil).Start), starter, apiServer)
 }
+
+// Status mocks base method.
+func (m *MockCluster) Status(name string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Status", name)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Status indicates an expected call of Status.
+func (mr *MockClusterMockRecorder) Status(name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockCluster)(nil).Status), name)
+}


### PR DESCRIPTION
Currently, if someone tries to apply against a stopped minikube cluster, they will receive the unhelpful message of

```console
│ Error: Request cancelled
│ 
│   with minikube_cluster.docker,
│   on main.tf line 5, in resource "minikube_cluster" "docker":
│    5: resource "minikube_cluster" "docker" {
│ 
│ The plugin.(*GRPCProvider).ReadResource request was cancelled.
```

This PR aims to instead return an error that indicates that the cluster is in a stopped state