### PR TITLE
use partial to support stopped clusters

### DIFF
--- a/minikube/service/minikube_client.go
+++ b/minikube/service/minikube_client.go
@@ -270,8 +270,7 @@ func (e *MinikubeClient) Delete() error {
 
 // GetClusterConfig retrieves the latest cluster config from minikube
 func (e *MinikubeClient) GetClusterConfig() *config.ClusterConfig {
-	cluster := e.nRunner.Get(e.clusterName)
-	return cluster.Config
+	return e.nRunner.Get(e.clusterName)
 }
 
 func (e *MinikubeClient) GetK8sVersion() string {

--- a/minikube/service/minikube_client_test.go
+++ b/minikube/service/minikube_client_test.go
@@ -9,7 +9,6 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	"k8s.io/minikube/pkg/minikube/config"
-	"k8s.io/minikube/pkg/minikube/mustload"
 	_ "k8s.io/minikube/pkg/minikube/registry/drvs"
 )
 
@@ -643,11 +642,11 @@ func TestMinikubeClient_GetAddons(t *testing.T) {
 		mockCluster := NewMockCluster(ctrl)
 		mockCluster.EXPECT().
 			Get(gomock.Any()).
-			Return(mustload.ClusterController{
-				Config: &config.ClusterConfig{
+			Return(
+				&config.ClusterConfig{
 					Addons: tt.fields.addons,
 				},
-			})
+			)
 
 		t.Run(tt.name, func(t *testing.T) {
 			e := &MinikubeClient{

--- a/minikube/service/minikube_cluster.go
+++ b/minikube/service/minikube_cluster.go
@@ -24,7 +24,7 @@ type Cluster interface {
 	Provision(cc *config.ClusterConfig, n *config.Node, apiServer bool, delOnFail bool) (command.Runner, bool, libmachine.API, *host.Host, error)
 	Start(starter node.Starter, apiServer bool) (*kubeconfig.Settings, error)
 	Delete(cc config.ClusterConfig, name string) (*config.Node, error)
-	Get(name string) mustload.ClusterController
+	Get(name string) *config.ClusterConfig
 	Add(cc *config.ClusterConfig, starter node.Starter) error
 	SetAddon(name string, addon string, value string) error
 	Status(name string) (string, error)
@@ -103,8 +103,9 @@ func (m *MinikubeCluster) SetAddon(name string, addon string, value string) erro
 	return minikubeAddons.SetAndSave(name, addon, value)
 }
 
-func (m *MinikubeCluster) Get(name string) mustload.ClusterController {
-	return mustload.Running(name)
+func (m *MinikubeCluster) Get(name string) *config.ClusterConfig {
+	_, config := mustload.Partial(name)
+	return config
 }
 
 func makeAllMinikubeDirectories() {

--- a/minikube/service/mock_minikube_cluster.go
+++ b/minikube/service/mock_minikube_cluster.go
@@ -13,7 +13,6 @@ import (
 	command "k8s.io/minikube/pkg/minikube/command"
 	config "k8s.io/minikube/pkg/minikube/config"
 	kubeconfig "k8s.io/minikube/pkg/minikube/kubeconfig"
-	mustload "k8s.io/minikube/pkg/minikube/mustload"
 	node "k8s.io/minikube/pkg/minikube/node"
 )
 
@@ -70,10 +69,10 @@ func (mr *MockClusterMockRecorder) Delete(cc, name interface{}) *gomock.Call {
 }
 
 // Get mocks base method.
-func (m *MockCluster) Get(name string) mustload.ClusterController {
+func (m *MockCluster) Get(name string) *config.ClusterConfig {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", name)
-	ret0, _ := ret[0].(mustload.ClusterController)
+	ret0, _ := ret[0].(*config.ClusterConfig)
 	return ret0
 }
 


### PR DESCRIPTION
Currently, if someone tries to apply against a stopped minikube cluster, they will receive the unhelpful message of

```console
│ Error: Request cancelled
│ 
│   with minikube_cluster.docker,
│   on main.tf line 5, in resource "minikube_cluster" "docker":
│    5: resource "minikube_cluster" "docker" {
│ 
│ The plugin.(*GRPCProvider).ReadResource request was cancelled.
```