### PR TITLE
Revert "provide helpful error when applying against a stopped cluster"

### DIFF
--- a/hack/main.go
+++ b/hack/main.go
@@ -48,7 +48,6 @@ func main() {
 	}
 
 	mountString, _ := schema["mount_string"].DefaultFunc()
-
 	cc := config.ClusterConfig{
 		Name:                    "terraform-provider-minikube-acc",
 		KeepContext:             schema["keep_context"].Default.(bool),
@@ -110,11 +109,6 @@ func main() {
 		MultiNodeRequested: false,
 	}
 
-	cluster, err := service.NewMinikubeCluster()
-	if err != nil {
-		println(err.Error())
-		os.Exit(1)
-	}
 	minikubeClient := service.NewMinikubeClient(
 		service.MinikubeClientConfig{
 			ClusterConfig:   cc,
@@ -123,7 +117,7 @@ func main() {
 			IsoUrls:         []string{"https://github.com/kubernetes/minikube/releases/download/v1.26.1/minikube-v1.26.1-amd64.iso"},
 			DeleteOnFailure: true},
 		service.MinikubeClientDeps{
-			Node:       cluster,
+			Node:       service.NewMinikubeCluster(),
 			Downloader: service.NewMinikubeDownloader(),
 		})
 

--- a/minikube/resource_cluster.go
+++ b/minikube/resource_cluster.go
@@ -370,13 +370,12 @@ func initialiseMinikubeClient(d *schema.ResourceData, m interface{}) (service.Cl
 		Nodes:           d.Get("nodes").(int),
 	})
 
-	cluster, err := service.NewMinikubeCluster()
 	clusterClient.SetDependencies(service.MinikubeClientDeps{
-		Node:       cluster,
+		Node:       service.NewMinikubeCluster(),
 		Downloader: service.NewMinikubeDownloader(),
 	})
 
-	return clusterClient, err
+	return clusterClient, nil
 }
 
 func getAddons(addons interface{}) []string {

--- a/minikube/service/minikube_client.go
+++ b/minikube/service/minikube_client.go
@@ -148,15 +148,6 @@ func (e *MinikubeClient) Start() (*kubeconfig.Settings, error) {
 
 	e.clusterConfig.MinikubeISO = url
 
-	status, err := e.nRunner.Status(e.clusterName)
-	if err != nil {
-		return nil, err
-	}
-
-	if status == "Stopped" {
-		return nil, fmt.Errorf("%s is currently stopped. Either start the cluster via minikube or try recreating it", e.clusterName)
-	}
-
 	mRunner, preExists, mAPI, host, err := e.nRunner.Provision(&e.clusterConfig, &e.clusterConfig.Nodes[0], true, true)
 	if err != nil {
 		return nil, err

--- a/minikube/service/minikube_client_test.go
+++ b/minikube/service/minikube_client_test.go
@@ -183,24 +183,6 @@ func TestMinikubeClient_Start(t *testing.T) {
 			},
 			wantErr: true,
 		},
-		{
-			name: "Stopped Cluster Failure",
-			fields: fields{
-				clusterConfig: config.ClusterConfig{
-					Nodes: []config.Node{
-						{},
-					},
-				},
-				addons:          []string{},
-				isoUrls:         []string{},
-				deleteOnFailure: true,
-				nRunner:         getStoppedCluster(ctrl),
-				dLoader:         getDownloadSuccess(ctrl),
-				nodes:           1,
-				tfCreationLock:  sync.Mutex{},
-			},
-			wantErr: true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -651,10 +633,6 @@ func getProvisionerFailure(ctrl *gomock.Controller) Cluster {
 		Provision(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil, false, nil, nil, errors.New("provision error"))
 
-	nRunnerProvisionFailure.EXPECT().
-		Status(gomock.Any()).
-		Return("", nil)
-
 	return nRunnerProvisionFailure
 }
 
@@ -669,21 +647,7 @@ func getStartFailure(ctrl *gomock.Controller) Cluster {
 		Start(gomock.Any(), true).
 		Return(nil, errors.New("start error"))
 
-	nRunnerStartFailure.EXPECT().
-		Status(gomock.Any()).
-		Return("", nil)
-
 	return nRunnerStartFailure
-}
-
-func getStoppedCluster(ctrl *gomock.Controller) Cluster {
-	nRunnerStatusStopped := NewMockCluster(ctrl)
-
-	nRunnerStatusStopped.EXPECT().
-		Status(gomock.Any()).
-		Return("Stopped", nil)
-
-	return nRunnerStatusStopped
 }
 
 func getDownloadFailure(ctrl *gomock.Controller) Downloader {
@@ -721,10 +685,6 @@ func getNodeSuccess(ctrl *gomock.Controller) Cluster {
 		Start(gomock.Any(), true).
 		Return(nil, nil)
 
-	nRunnerSuccess.EXPECT().
-		Status(gomock.Any()).
-		Return("", nil)
-
 	return nRunnerSuccess
 }
 
@@ -744,10 +704,6 @@ func getMultipleNodesSuccess(ctrl *gomock.Controller, n int) Cluster {
 		Return(nil).
 		Times(n - 1)
 
-	nRunnerSuccess.EXPECT().
-		Status(gomock.Any()).
-		Return("", nil)
-
 	return nRunnerSuccess
 }
 
@@ -765,10 +721,6 @@ func getMultipleNodesFailure(ctrl *gomock.Controller) Cluster {
 	nRunnerSuccess.EXPECT().
 		Add(gomock.Any(), gomock.Any()).
 		Return(errors.New("error adding node"))
-
-	nRunnerSuccess.EXPECT().
-		Status(gomock.Any()).
-		Return("", nil)
 
 	return nRunnerSuccess
 }

--- a/minikube/service/minikube_client_test.go
+++ b/minikube/service/minikube_client_test.go
@@ -201,24 +201,6 @@ func TestMinikubeClient_Start(t *testing.T) {
 			},
 			wantErr: true,
 		},
-		{
-			name: "Status Failure",
-			fields: fields{
-				clusterConfig: config.ClusterConfig{
-					Nodes: []config.Node{
-						{},
-					},
-				},
-				addons:          []string{},
-				isoUrls:         []string{},
-				deleteOnFailure: true,
-				nRunner:         getStatusFailure(ctrl),
-				dLoader:         getDownloadSuccess(ctrl),
-				nodes:           1,
-				tfCreationLock:  sync.Mutex{},
-			},
-			wantErr: true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -700,16 +682,6 @@ func getStoppedCluster(ctrl *gomock.Controller) Cluster {
 	nRunnerStatusStopped.EXPECT().
 		Status(gomock.Any()).
 		Return("Stopped", nil)
-
-	return nRunnerStatusStopped
-}
-
-func getStatusFailure(ctrl *gomock.Controller) Cluster {
-	nRunnerStatusStopped := NewMockCluster(ctrl)
-
-	nRunnerStatusStopped.EXPECT().
-		Status(gomock.Any()).
-		Return("", errors.New("oh nooo"))
 
 	return nRunnerStatusStopped
 }

--- a/minikube/service/minikube_cluster.go
+++ b/minikube/service/minikube_cluster.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/kubeconfig"
 	"k8s.io/minikube/pkg/minikube/localpath"
-	"k8s.io/minikube/pkg/minikube/machine"
 	"k8s.io/minikube/pkg/minikube/mustload"
 	"k8s.io/minikube/pkg/minikube/node"
 	"k8s.io/minikube/pkg/minikube/reason"
@@ -27,17 +26,14 @@ type Cluster interface {
 	Get(name string) mustload.ClusterController
 	Add(cc *config.ClusterConfig, starter node.Starter) error
 	SetAddon(name string, addon string, value string) error
-	Status(name string) (string, error)
 }
 
 type MinikubeCluster struct {
 	workerNodes int
-	machineAPI  libmachine.API
 }
 
-func NewMinikubeCluster() (*MinikubeCluster, error) {
-	machineAPI, err := machine.NewAPIClient()
-	return &MinikubeCluster{workerNodes: 0, machineAPI: machineAPI}, err
+func NewMinikubeCluster() *MinikubeCluster {
+	return &MinikubeCluster{workerNodes: 0}
 }
 
 func (m *MinikubeCluster) Provision(cc *config.ClusterConfig, n *config.Node, apiServer bool, delOnFail bool) (command.Runner, bool, libmachine.API, *host.Host, error) {
@@ -53,11 +49,6 @@ func (m *MinikubeCluster) Provision(cc *config.ClusterConfig, n *config.Node, ap
 func (m *MinikubeCluster) Start(starter node.Starter, apiServer bool) (*kubeconfig.Settings, error) {
 
 	return node.Start(starter, apiServer)
-}
-
-func (m *MinikubeCluster) Status(name string) (string, error) {
-
-	return machine.Status(m.machineAPI, name)
 }
 
 // Add adds nodes to the clusters node pool

--- a/minikube/service/mock_minikube_cluster.go
+++ b/minikube/service/mock_minikube_cluster.go
@@ -129,18 +129,3 @@ func (mr *MockClusterMockRecorder) Start(starter, apiServer interface{}) *gomock
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockCluster)(nil).Start), starter, apiServer)
 }
-
-// Status mocks base method.
-func (m *MockCluster) Status(name string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Status", name)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Status indicates an expected call of Status.
-func (mr *MockClusterMockRecorder) Status(name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockCluster)(nil).Status), name)
-}


### PR DESCRIPTION
Not convinced this can actually be triggered as it will fail during the read stage. This is a better solution to the original issue https://github.com/scott-the-programmer/terraform-provider-minikube/pull/60