### PR TITLE
Fix "Error: Failed to start host: creating host: create: provisioning: ssh command error"

### DIFF
--- a/hack/main.go
+++ b/hack/main.go
@@ -115,7 +115,9 @@ func main() {
 			ClusterName:     "terraform-provider-minikube-acc",
 			Addons:          []string{},
 			IsoUrls:         []string{"https://github.com/kubernetes/minikube/releases/download/v1.30.1/minikube-v1.30.1-amd64.iso"},
-			DeleteOnFailure: true},
+			NativeSsh:       true,
+			DeleteOnFailure: true,
+		},
 		service.MinikubeClientDeps{
 			Node:       service.NewMinikubeCluster(),
 			Downloader: service.NewMinikubeDownloader(),

--- a/minikube/resource_cluster.go
+++ b/minikube/resource_cluster.go
@@ -368,6 +368,7 @@ func initialiseMinikubeClient(d *schema.ResourceData, m interface{}) (service.Cl
 		IsoUrls:         state_utils.ReadSliceState(defaultIsos),
 		DeleteOnFailure: d.Get("delete_on_failure").(bool),
 		Nodes:           d.Get("nodes").(int),
+		NativeSsh:       d.Get("native_ssh").(bool),
 	})
 
 	clusterClient.SetDependencies(service.MinikubeClientDeps{


### PR DESCRIPTION
Fixes an issue where the external ssh client is used instead of the native ssh client. This can cause a delay between the docker container starting sshd while minikube is trying to ssh in. The net result is partially configured container which often results in [apiServer.certSANs: Invalid value: ""](https://github.com/scott-the-programmer/terraform-provider-minikube/issues/57)

Tested on Elementary OS using the docker driver

TODO:
- [x] validate on windows (docker / hyperv)
- [x] validate on osx (docker / hyperkit)