### PR TITLE
Set `storageProvisionerVersion` to support storage-provisioner addon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ crash.log
 .terraform
 test_output
 schema-generator
+testBinary

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,6 +15,7 @@ builds:
     - -trimpath
   ldflags:
     - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+    - '-X k8s.io/minikube/pkg/version.storageProvisionerVersion=v5'
   goos:
     - freebsd
     - windows

--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,10 @@ test-stack: set-local
 	terraform -chdir=examples/resources/minikube_cluster apply --auto-approve
 	terraform -chdir=examples/resources/minikube_cluster destroy --auto-approve
 
+STORAGE_PROVISIONER_TAG ?= v5
 .PHONY: build
 build:
-	go build -o bin/terraform-provider-minikube
+	go build -o bin/terraform-provider-minikube -ldflags="-X k8s.io/minikube/pkg/version.storageProvisionerVersion=$(STORAGE_PROVISIONER_TAG)"
 
 .PHONY: set-local 
 set-local: build	

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,8 @@ test:
 .PHONY: acceptance
 acceptance:
 	go clean -testcache
-	TF_ACC=true go test ./minikube -run "TestClusterCreation" -v -p 1 --timeout 20m
+	go test -c -ldflags="-X k8s.io/minikube/pkg/version.storageProvisionerVersion=v5" -o testBinary ./minikube 
+	TF_ACC=true ./testBinary -test.run "TestClusterCreation" -test.v -test.parallel 1 -test.timeout 20m
 
 .PHONY: test-stack
 test-stack: set-local

--- a/minikube/resource_cluster.go
+++ b/minikube/resource_cluster.go
@@ -387,16 +387,8 @@ func initialiseMinikubeClient(d *schema.ResourceData, m interface{}) (service.Cl
 
 func getAddons(addons interface{}) []string {
 	addonStrings := make([]string, len(addons.([]interface{})))
-	userDefinedStorageClass := false
 	for i, v := range addons.([]interface{}) {
-		if v == "default-storageclass" {
-			userDefinedStorageClass = true
-		}
 		addonStrings[i] = v.(string)
-	}
-
-	if !userDefinedStorageClass {
-		addonStrings = append(addonStrings, "default-storageclass")
 	}
 
 	sort.Strings(addonStrings) //to ensure consistency with TF state


### PR DESCRIPTION
This PR attempts to fix https://github.com/scott-the-programmer/terraform-provider-minikube/issues/71  by setting the storageProvisionerVersion during the build / release. Internally, this is used to grab the [storage provisioner image](https://github.com/kubernetes/minikube/blob/40e86860211a515d2801a08d269b970b3cac232e/pkg/minikube/bootstrapper/images/images.go#L155) in the provisioning stage. 

<img width="719" alt="image" src="https://github.com/scott-the-programmer/terraform-provider-minikube/assets/19235440/9b32fd57-5a7e-459f-8fef-75500982085c">

Closes https://github.com/scott-the-programmer/terraform-provider-minikube/issues/71 