### PR TITLE
sets ContainerVolumeMounts when a container driver is selected

### DIFF
--- a/minikube/service/minikube_client.go
+++ b/minikube/service/minikube_client.go
@@ -21,6 +21,11 @@ import (
 	_ "k8s.io/minikube/pkg/minikube/registry/drvs"
 )
 
+const (
+	Podman = "podman"
+	Docker = "docker"
+)
+
 type ClusterClient interface {
 	SetConfig(args MinikubeClientConfig)
 	GetConfig() MinikubeClientConfig
@@ -144,6 +149,9 @@ func (e *MinikubeClient) Start() (*kubeconfig.Settings, error) {
 	}
 
 	e.clusterConfig.MinikubeISO = url
+	if e.clusterConfig.Driver == Podman || e.clusterConfig.Driver == Docker { // use volume mounts for container runtimes
+		e.clusterConfig.ContainerVolumeMounts = []string{e.clusterConfig.MountString}
+	}
 
 	if e.nativeSsh {
 		ssh.SetDefaultClient(ssh.Native)


### PR DESCRIPTION
Quick follow up for https://github.com/scott-the-programmer/terraform-provider-minikube/issues/86. After testing locally, It appears that we should set ContainerVolumeMounts when Podman or Docker is specified (as seen [here](https://github.com/kubernetes/minikube/blob/f58582b7eb7b72a261c68a41d00be86bf69f952e/cmd/minikube/cmd/start_flags.go#L597)). This wouldn't impact the VM drivers (hyperkit, hyper-v, etc)