### PR TITLE
recommend setting cni = "bridge" in the default setup + minor doc tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ provider minikube {
 }
 
 resource "minikube_cluster" "cluster" {
-  vm = true
-  driver = "hyperkit"
-  addons = [
+  vm      = true
+  driver  = "hyperkit"
+  cni     = "bridge"
+  addons  = [
     "dashboard",
     "default-storageclass",
     "ingress",

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,14 +20,6 @@ minikube start --driver=docker --download-only
 
 Some drivers require a bit of prerequisite setup, so it's best to visit [https://minikube.sigs.k8s.io/docs/drivers/](https://minikube.sigs.k8s.io/docs/drivers/) first
 
-```bash
-#x86_64
-curl https://raw.githubusercontent.com/scott-the-programmer/terraform-provider-minikube/main/bootstrap/install-driver.sh | sudo bash -s "kvm2"
-
-#arm64
-curl https://raw.githubusercontent.com/scott-the-programmer/terraform-provider-minikube/main/bootstrap/install-driver.sh | sudo bash -s "kvm2" "arm64"
-```
-
 ## Example Usage
 
 ```terraform

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -31,6 +31,7 @@ resource "minikube_cluster" "hyperkit" {
   driver       = "hyperkit"
   cluster_name = "terraform-provider-minikube-acc-hyperkit"
   nodes        = 3
+  cni          = "bridge" # Allows pods to communicate with each other via DNS
   addons = [
     "dashboard",
     "default-storageclass",

--- a/examples/resources/minikube_cluster/resource.tf
+++ b/examples/resources/minikube_cluster/resource.tf
@@ -16,6 +16,7 @@ resource "minikube_cluster" "hyperkit" {
   driver       = "hyperkit"
   cluster_name = "terraform-provider-minikube-acc-hyperkit"
   nodes        = 3
+  cni          = "bridge" # Allows pods to communicate with each other via DNS
   addons = [
     "dashboard",
     "default-storageclass",

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -20,14 +20,6 @@ minikube start --driver=docker --download-only
 
 Some drivers require a bit of prerequisite setup, so it's best to visit [https://minikube.sigs.k8s.io/docs/drivers/](https://minikube.sigs.k8s.io/docs/drivers/) first
 
-```bash
-#x86_64
-curl https://raw.githubusercontent.com/scott-the-programmer/terraform-provider-minikube/main/bootstrap/install-driver.sh | sudo bash -s "kvm2"
-
-#arm62
-curl https://raw.githubusercontent.com/scott-the-programmer/terraform-provider-minikube/main/bootstrap/install-driver.sh | sudo bash -s "kvm2" "arm64"
-```
-
 ## Example Usage
 
 {{ tffile "examples/provider/provider.tf" }}


### PR DESCRIPTION
Feedback from https://github.com/scott-the-programmer/terraform-provider-minikube/issues/90#issuecomment-1690116207. Since cni = bridge is implicitly added in minikube, I don't see any harm in including this in the base example.

Also minor doc tweaks (remove deprecated section + formatting)