### PR TITLE
upgrade to klog v2 for better coexistance with glog

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.28.0
 	github.com/spf13/viper v1.16.0
 	github.com/stretchr/testify v1.8.4
-	k8s.io/klog v1.0.0
+	k8s.io/klog/v2 v2.100.1
 	k8s.io/minikube v1.31.0
 )
 
@@ -238,7 +238,6 @@ require (
 	k8s.io/client-go v0.27.3 // indirect
 	k8s.io/cluster-bootstrap v0.0.0 // indirect
 	k8s.io/component-base v0.27.3 // indirect
-	k8s.io/klog/v2 v2.100.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f // indirect
 	k8s.io/kubectl v0.27.3 // indirect
 	k8s.io/utils v0.0.0-20230209194617-a36077c30491 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1584,8 +1584,6 @@ k8s.io/cluster-bootstrap v0.22.4/go.mod h1:fTQZ6u9G6fg2LHhB8nEgZLnXIhCDSRYuLUUS5
 k8s.io/component-base v0.27.3 h1:g078YmdcdTfrCE4fFobt7qmVXwS8J/3cI1XxRi/2+6k=
 k8s.io/component-base v0.27.3/go.mod h1:JNiKYcGImpQ44iwSYs6dysxzR9SxIIgQalk4HaCNVUY=
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
-k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
-k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.9.0/go.mod h1:hy9LJ/NvuK+iVyP4Ehqva4HxZG/oXyIS3n3Jmire4Ec=
 k8s.io/klog/v2 v2.100.1 h1:7WCHKK6K8fNhTqfBhISHQ97KrnJNFZMcQvKp7gP/tmg=

--- a/minikube/service/minikube_client.go
+++ b/minikube/service/minikube_client.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/docker/machine/libmachine/ssh"
 	"github.com/spf13/viper"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	cmdcfg "k8s.io/minikube/cmd/minikube/cmd/config"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/kubeconfig"

--- a/minikube/service/minikube_log.go
+++ b/minikube/service/minikube_log.go
@@ -10,7 +10,7 @@ import (
 
 	mlog "github.com/docker/machine/libmachine/log"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 var (


### PR DESCRIPTION
If terraform-provider-minikube is called as a lib (i.e. through [terraform-pulumi-bridge](https://github.com/pulumi/pulumi-terraform-bridge)), it can cause flag conflicts if the application also imports glog. 

To fix this, we can use v2 to co-exist with glog as shown in [this example](https://github.com/kubernetes/klog/blob/main/examples/coexist_glog/coexist_glog.go)