### PR TITLE
avoid IP conflict by adding nodes after the control plane node

### DIFF
--- a/examples/resources/minikube_cluster/resource.tf
+++ b/examples/resources/minikube_cluster/resource.tf
@@ -5,7 +5,7 @@ provider "minikube" {
 resource "minikube_cluster" "docker" {
   driver       = "docker"
   cluster_name = "terraform-provider-minikube-acc-docker"
-  addons = [
+    addons = [
     "default-storageclass",
     "storage-provisioner"
   ]
@@ -57,7 +57,7 @@ resource "kubernetes_deployment" "deployment" {
       }
       spec {
         container {
-          image = "nginx:1.7.8"
+          image = "nginx:latest"
           name  = "example"
 
           port {

--- a/minikube/service/minikube_cluster.go
+++ b/minikube/service/minikube_cluster.go
@@ -59,7 +59,8 @@ func (m *MinikubeCluster) Start(starter node.Starter, apiServer bool) (*kubeconf
 // Add adds nodes to the clusters node pool
 func (m *MinikubeCluster) Add(cc *config.ClusterConfig, starter node.Starter) error {
 	n := config.Node{
-		Name:              node.Name(m.workerNodes + m.controlPlaneNodes + 1), // index starts from 1
+		// index starts from 1 https://github.com/kubernetes/minikube/blob/075c1b01f2f8778ac746e05098044234a3f0b06f/pkg/minikube/driver/driver.go#L387C4-L387C27
+		Name:              node.Name(m.workerNodes + m.controlPlaneNodes + 1),
 		Worker:            true,
 		ControlPlane:      false,
 		KubernetesVersion: starter.Cfg.KubernetesConfig.KubernetesVersion,


### PR DESCRIPTION
Fixes https://github.com/scott-the-programmer/terraform-provider-minikube/issues/97

Currently, minikube assigns the[ IP address based on the node name](https://github.com/kubernetes/minikube/blob/master/pkg/minikube/driver/driver.go#L379). The bug here is that we index the worker nodes from 0, causing a conflict on the original control plane node.

To fix this, we should A) start indexing from 1 (since the control plane node starts at 1) and B) append after the control plane node (2,3,4...)