### PR TITLE
fix(apiservernames): use apiservernnames field

### DIFF
--- a/minikube/resource_cluster.go
+++ b/minikube/resource_cluster.go
@@ -271,13 +271,18 @@ func initialiseMinikubeClient(d *schema.ResourceData, m interface{}) (service.Cl
 		return nil, err
 	}
 
+	apiserverNames := []string{}
+	if d.Get("apiserver_names").(*schema.Set).Len() > 0 {
+		apiserverNames = state_utils.ReadSliceState(d.Get("apiserver_names"))
+	}
+
 	k8sVersion := clusterClient.GetK8sVersion()
 	kubernetesConfig := config.KubernetesConfig{
 		KubernetesVersion: k8sVersion,
 		ClusterName:       d.Get("cluster_name").(string),
 		Namespace:         d.Get("namespace").(string),
 		APIServerName:     d.Get("apiserver_name").(string),
-		APIServerNames:    []string{d.Get("apiserver_name").(string)},
+		APIServerNames:    apiserverNames,
 		DNSDomain:         d.Get("dns_domain").(string),
 		FeatureGates:      d.Get("feature_gates").(string),
 		ContainerRuntime:  d.Get("container_runtime").(string),

--- a/minikube/resource_cluster_test.go
+++ b/minikube/resource_cluster_test.go
@@ -258,13 +258,15 @@ func getBaseMockClient(ctrl *gomock.Controller, clusterName string) *service.Moc
 	clusterSchema := ResourceCluster().Schema
 	mountString, _ := clusterSchema["mount_string"].DefaultFunc()
 
+
+
 	k8sVersion := "v1.26.3"
 	kubernetesConfig := config.KubernetesConfig{
 		KubernetesVersion:      k8sVersion,
 		ClusterName:            clusterName,
 		Namespace:              clusterSchema["namespace"].Default.(string),
 		APIServerName:          clusterSchema["apiserver_name"].Default.(string),
-		APIServerNames:         []string{clusterSchema["apiserver_name"].Default.(string)},
+		APIServerNames:         []string{"minikubeCA"},
 		DNSDomain:              clusterSchema["dns_domain"].Default.(string),
 		FeatureGates:           clusterSchema["feature_gates"].Default.(string),
 		ContainerRuntime:       clusterSchema["container_runtime"].Default.(string),

--- a/minikube/schema_cluster.go
+++ b/minikube/schema_cluster.go
@@ -98,7 +98,7 @@ var (
 			
 			Optional:			true,
 			ForceNew:			true,
-			
+		
 			Elem: &schema.Schema{
 				Type:	schema.TypeString,
 			},


### PR DESCRIPTION
Faced a  bug where I wasn't able to set `apiservernnames`, because the wrong attribute was read during create.

I noticed you use a lot of `TypeSet` for Lists of String. I would rather use `TypeList` for these Attributes or Limit `TypeSet` with `MaxItem: 1`.  Otherwise there is a chance that the Items in the Set have duplicate elements.
