### PR TITLE
refactor debug binary target to be OS specific

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,36 +41,36 @@ STORAGE_PROVISIONER_TAG ?= v5
 build:
 	go build -o bin/terraform-provider-minikube -ldflags="-X k8s.io/minikube/pkg/version.storageProvisionerVersion=$(STORAGE_PROVISIONER_TAG)"
 
-.PHONY: set-local 
-set-local: build	
-ifeq ($(OS), Windows_NT)
-#amd64
-	mkdir -p $$APPDATA/terraform.d/plugins/registry.terraform.io/scott-the-programmer/minikube/99.99.99/windows_amd64 
-	cp bin/terraform-provider-minikube $$APPDATA/terraform.d/plugins/registry.terraform.io/scott-the-programmer/minikube/99.99.99/windows_amd64/terraform-provider-minikube.exe
-
-#arm64
-	mkdir -p $$APPDATA/terraform.d/plugins/registry.terraform.io/scott-the-programmer/minikube/99.99.99/windows_arm64 
-	cp bin/terraform-provider-minikube $$APPDATA/terraform.d/plugins/registry.terraform.io/scott-the-programmer/minikube/99.99.99/windows_arm64/terraform-provider-minikube.exe
-
+ARCH_RAW := $(shell uname -m)
+ifeq ($(ARCH_RAW), x86_64)
+	ARCH := amd64
+else ifeq ($(ARCH_RAW), aarch64)
+	ARCH := arm64
 else
-#amd64
-	mkdir -p $$HOME/.terraform.d/plugins/registry.terraform.io/scott-the-programmer/minikube/99.99.99/linux_amd64 
-	mkdir -p $$HOME/.terraform.d/plugins/registry.terraform.io/scott-the-programmer/minikube/99.99.99/darwin_amd64 
-	cp bin/terraform-provider-minikube $$HOME/.terraform.d/plugins/registry.terraform.io/scott-the-programmer/minikube/99.99.99/linux_amd64/terraform-provider-minikube
-	cp bin/terraform-provider-minikube $$HOME/.terraform.d/plugins/registry.terraform.io/scott-the-programmer/minikube/99.99.99/darwin_amd64/terraform-provider-minikube
-
-#arm64
-	mkdir -p $$HOME/.terraform.d/plugins/registry.terraform.io/scott-the-programmer/minikube/99.99.99/linux_arm64 
-	mkdir -p $$HOME/.terraform.d/plugins/registry.terraform.io/scott-the-programmer/minikube/99.99.99/darwin_arm64 
-	cp bin/terraform-provider-minikube $$HOME/.terraform.d/plugins/registry.terraform.io/scott-the-programmer/minikube/99.99.99/linux_arm64/terraform-provider-minikube
-	cp bin/terraform-provider-minikube $$HOME/.terraform.d/plugins/registry.terraform.io/scott-the-programmer/minikube/99.99.99/darwin_arm64/terraform-provider-minikube
+	ARCH := $(ARCH_RAW)
 endif
 
+OS_NAME := $(shell uname -s | tr A-Z a-z)
+PLUGIN_NAME := terraform-provider-minikube
+VERSION := 99.99.99
+DEST_DIR := $$HOME/.terraform.d/plugins/registry.terraform.io/scott-the-programmer/minikube/$(VERSION)
+EXT :=
 
+ifeq ($(OS), Windows_NT)
+	OS_NAME := windows
+	DEST_DIR := $$APPDATA/terraform.d/plugins/registry.terraform.io/scott-the-programmer/minikube/$(VERSION)
+	EXT := .exe
+endif
 
-
-.PHONY: set-local-windows
+.PHONY: set-local
 set-local: build
+	mkdir -p $(DEST_DIR)/$(OS_NAME)_$(ARCH) && \
+	cp bin/$(PLUGIN_NAME) $(DEST_DIR)/$(OS_NAME)_$(ARCH)/$(PLUGIN_NAME)$(EXT)
+
+.PHONY: reset-local
+reset-local:
+	rm -rf $(DEST_DIR)/$(OS_NAME)_$(ARCH)/$(PLUGIN_NAME)$(EXT)
+
 
 SED_FLAGS := -i
 UNAME_S := $(shell uname -s)

--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,17 @@ acceptance:
 	go test -c -ldflags="-X k8s.io/minikube/pkg/version.storageProvisionerVersion=v5" -o testBinary ./minikube 
 	TF_ACC=true ./testBinary -test.run "TestClusterCreation" -test.v -test.parallel 1 -test.timeout 20m
 
-.PHONY: test-stack
-test-stack: set-local
+.PHONY: test-stack-apply
+test-stack-apply: set-local
 	terraform -chdir=examples/resources/minikube_cluster init || true
 	terraform -chdir=examples/resources/minikube_cluster apply --auto-approve
+
+.PHONY: test-stack-delete
+test-stack-delete:
 	terraform -chdir=examples/resources/minikube_cluster destroy --auto-approve
+
+.PHONY: test-stack
+test-stack: test-stack-apply test-stack-delete
 
 STORAGE_PROVISIONER_TAG ?= v5
 .PHONY: build


### PR DESCRIPTION
a minor fix to the set-local makefile target so it only writes the binary needed for the current os

also included reset-local so that we can clean up said binary