### PR TITLE
feat(extra_configs): support extra config

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -32,6 +32,12 @@ resource "minikube_cluster" "hyperkit" {
   cluster_name = "terraform-provider-minikube-acc-hyperkit"
   nodes        = 3
   cni          = "bridge" # Allows pods to communicate with each other via DNS
+
+  # pass extra configs to control plane components (syntax: "<component>.<key>=<value>")
+  extra_config = [
+    "apiserver.encryption-provider-config=/etc/kubernetes/manifests/encryption_provider_config.yml"
+  ]
+
   addons = [
     "dashboard",
     "default-storageclass",

--- a/minikube/resource_cluster_test.go
+++ b/minikube/resource_cluster_test.go
@@ -77,6 +77,21 @@ func TestClusterCreation_Docker(t *testing.T) {
 	})
 }
 
+func TestClusterCreation_Docker_ExtraConfig(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers:    map[string]*schema.Provider{"minikube": Provider()},
+		CheckDestroy: verifyDelete,
+		Steps: []resource.TestStep{
+			{
+				Config: testAcceptanceClusterExtraConfig("docker", "TestClusterCreationDocker"),
+				Check: resource.ComposeTestCheckFunc(
+					testPropertyExists("minikube_cluster.new", "TestClusterCreationDocker"),
+				),
+			},
+		},
+	})
+}
+
 func TestClusterCreation_Docker_Update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		Providers:    map[string]*schema.Provider{"minikube": Provider()},
@@ -431,6 +446,24 @@ func testAcceptanceClusterConfig(driver string, clusterName string) string {
 		cpus = 2 
 		memory = "6GiB"
 
+		addons = [
+			"dashboard",
+			"default-storageclass",
+			"storage-provisioner",
+		]
+	}
+	`, driver, clusterName)
+}
+
+func testAcceptanceClusterExtraConfig(driver string, clusterName string) string {
+	return fmt.Sprintf(`
+	resource "minikube_cluster" "new" {
+		driver = "%s"
+		cluster_name = "%s"
+		cpus = 2 
+		memory = "6GiB"
+
+		extra_config = ["apiserver.v=3"]
 		addons = [
 			"dashboard",
 			"default-storageclass",

--- a/minikube/schema_cluster.go
+++ b/minikube/schema_cluster.go
@@ -365,13 +365,15 @@ var (
 		},
 	
 		"extra_config": {
-			Type:					schema.TypeString,
+			Type:					schema.TypeList,
 			Description:	"A set of key=value pairs that describe configuration that may be passed to different components. 		The key should be '.' separated, and the first part before the dot is the component to apply the configuration to. 		Valid components are: kubelet, kubeadm, apiserver, controller-manager, etcd, proxy, scheduler 		Valid kubeadm parameters: ignore-preflight-errors, dry-run, kubeconfig, kubeconfig-dir, node-name, cri-socket, experimental-upload-certs, certificate-key, rootfs, skip-phases, pod-network-cidr",
 			
 			Optional:			true,
 			ForceNew:			true,
 			
-			Default:	"",
+			Elem: &schema.Schema{
+				Type:	schema.TypeString,
+			},
 		},
 	
 		"extra_disks": {


### PR DESCRIPTION
This PR enables the option to specify `extra_options`

example:

```hcl
resource "minikube_cluster" "docker" {
  driver       = "docker"
  cluster_name = "vault-playground"
  cni          = "bridge"

  listen_address = "0.0.0.0"

  apiserver_names = [
    "host.docker.internal"
  ]

  ports = [
    "8443:8443"
  ]

  extra_config = var.kms_enabled ? ["apiserver.encryption-provider-config=/etc/kubernetes/manifests/encryption_provider_config.yml"] : null

  addons = [
    "dashboard",
    "default-storageclass",
    "storage-provisioner",
    "ingress"
  ]
}
```

results in:

```bash
$> minikube ssh "sudo cat /etc/kubernetes/manifests/kube-apiserver.yaml" | grep encryption
    - --encryption-provider-config=/etc/kubernetes/manifests/encryption_provider_config.yml   ```