### PR TITLE
minor schema override for extra_config

### DIFF
--- a/minikube/generator/schema_builder.go
+++ b/minikube/generator/schema_builder.go
@@ -90,6 +90,10 @@ var schemaOverrides map[string]SchemaOverride = map[string]SchemaOverride{
 				return "/home:/minikube-host", nil
 			}`,
 	},
+	"extra_config": {
+		Description: "A set of key=value pairs that describe configuration that may be passed to different components. 		The key should be '.' separated, and the first part before the dot is the component to apply the configuration to. 		Valid components are: kubelet, kubeadm, apiserver, controller-manager, etcd, proxy, scheduler 		Valid kubeadm parameters: ignore-preflight-errors, dry-run, kubeconfig, kubeconfig-dir, node-name, cri-socket, experimental-upload-certs, certificate-key, rootfs, skip-phases, pod-network-cidr",
+		Type:        Array,
+	},
 }
 
 func run(ctx context.Context, args ...string) (string, error) {

--- a/minikube/schema_cluster.go
+++ b/minikube/schema_cluster.go
@@ -365,7 +365,7 @@ var (
 		},
 	
 		"extra_config": {
-			Type:					schema.TypeList,
+			Type:					schema.TypeSet,
 			Description:	"A set of key=value pairs that describe configuration that may be passed to different components. 		The key should be '.' separated, and the first part before the dot is the component to apply the configuration to. 		Valid components are: kubelet, kubeadm, apiserver, controller-manager, etcd, proxy, scheduler 		Valid kubeadm parameters: ignore-preflight-errors, dry-run, kubeconfig, kubeconfig-dir, node-name, cri-socket, experimental-upload-certs, certificate-key, rootfs, skip-phases, pod-network-cidr",
 			
 			Optional:			true,
@@ -374,6 +374,7 @@ var (
 			Elem: &schema.Schema{
 				Type:	schema.TypeString,
 			},
+			
 		},
 	
 		"extra_disks": {


### PR DESCRIPTION
Minor amendment to the schema generator to prevent extra_config being overridden. 

Honestly, have been going back and forth between removing the generator entirely. It was useful in the early stages of the project, but now the schema is relatively stable on both both ends (including minikube), it seems easier to delete it and just maintain schema_cluster.go exclusively

🤷🏽 

Note: this has no impact on functionality outside of using a Set instead of a List (prevents ordering diffs)