### PR TITLE
Fix multinode networking when using cni=auto

### DIFF
--- a/hack/main.go
+++ b/hack/main.go
@@ -27,14 +27,14 @@ func main() {
 		APIServerNames:    []string{schema["apiserver_name"].Default.(string)},
 		DNSDomain:         schema["dns_domain"].Default.(string),
 		FeatureGates:      schema["feature_gates"].Default.(string),
-		ContainerRuntime:  schema["container_runtime"].Default.(string),
+		ContainerRuntime:  driver,
 		CRISocket:         schema["cri_socket"].Default.(string),
-		NetworkPlugin:     schema["network_plugin"].Default.(string),
+		NetworkPlugin:     "cni",
 		ServiceCIDR:       schema["service_cluster_ip_range"].Default.(string),
 		ImageRepository:   "",
 		// ExtraOptions:           schema["extra_config"].Default.(string),
 		ShouldLoadCachedImages: schema["cache_images"].Default.(bool),
-		CNI:                    schema["cni"].Default.(string),
+		CNI:                    "auto",
 		NodePort:               schema["apiserver_port"].Default.(int),
 	}
 
@@ -106,7 +106,7 @@ func main() {
 			n,
 		},
 		KubernetesConfig:   kubernetesConfig,
-		MultiNodeRequested: false,
+		MultiNodeRequested: true,
 	}
 
 	minikubeClient := lib.NewMinikubeClient(
@@ -117,6 +117,7 @@ func main() {
 			IsoUrls:         []string{"https://github.com/kubernetes/minikube/releases/download/v1.32.0/minikube-v1.32.0-amd64.iso"},
 			NativeSsh:       true,
 			DeleteOnFailure: true,
+			Nodes:           3,
 		},
 		lib.MinikubeClientDeps{
 			Node:       lib.NewMinikubeCluster(),

--- a/minikube/generator/schema_builder.go
+++ b/minikube/generator/schema_builder.go
@@ -73,6 +73,11 @@ var schemaOverrides map[string]SchemaOverride = map[string]SchemaOverride{
 		Description: "Driver is one of the following - Windows: (hyperv, docker, virtualbox, vmware, qemu2, ssh) - OSX: (virtualbox, parallels, vmwarefusion, hyperkit, vmware, qemu2, docker, podman, ssh) - Linux: (docker, kvm2, virtualbox, qemu2, none, podman, ssh)",
 		Type:        String,
 	},
+	"container_runtime": {
+		Default:     "docker",
+		Description: "The container runtime to be used. Valid options: docker, cri-o, containerd (default: docker)",
+		Type:        String,
+	},
 	// Default schema to unix file paths first and let the provider translate them during runtime
 	"mount_string": {
 		Description: "The argument to pass the minikube mount command on start.",

--- a/minikube/resource_cluster.go
+++ b/minikube/resource_cluster.go
@@ -286,6 +286,14 @@ func initialiseMinikubeClient(d *schema.ResourceData, m interface{}) (lib.Cluste
 		apiserverNames = state_utils.ReadSliceState(d.Get("apiserver_names"))
 	}
 
+	networkPlugin := d.Get("network_plugin").(string) // This is a deprecated parameter in Minikube, however,
+	// it is still used internally, so we need to set it to a default value if it is not set. We should expect
+	// this to be a blank string usually, which should default to cni
+	// Upstream : https://github.com/kubernetes/minikube/blob/37eeaddf7ad63a7f690129247650e8dd4ff3d56a/cmd/minikube/cmd/start_flags.go#L506-L514
+	if networkPlugin == "" {
+		networkPlugin = "cni"
+	}
+
 	ecSlice := []string{}
 	if d.Get("extra_config") != nil && d.Get("extra_config").(*schema.Set).Len() > 0 {
 		ecSlice = state_utils.ReadSliceState(d.Get("extra_config"))
@@ -309,7 +317,7 @@ func initialiseMinikubeClient(d *schema.ResourceData, m interface{}) (lib.Cluste
 		FeatureGates:           d.Get("feature_gates").(string),
 		ContainerRuntime:       containerRuntime,
 		CRISocket:              d.Get("cri_socket").(string),
-		NetworkPlugin:          d.Get("network_plugin").(string),
+		NetworkPlugin:          networkPlugin,
 		ServiceCIDR:            d.Get("service_cluster_ip_range").(string),
 		ImageRepository:        "",
 		ExtraOptions:           extraConfigs,

--- a/minikube/resource_cluster.go
+++ b/minikube/resource_cluster.go
@@ -329,6 +329,13 @@ func initialiseMinikubeClient(d *schema.ResourceData, m interface{}) (lib.Cluste
 		addonConfig[addon] = true
 	}
 
+	nodes := d.Get("nodes").(int)
+	multiNode := false
+
+	if nodes > 1 {
+		multiNode = true
+	}
+
 	cc := config.ClusterConfig{
 		Addons:                  addonConfig,
 		Name:                    d.Get("cluster_name").(string),
@@ -388,7 +395,7 @@ func initialiseMinikubeClient(d *schema.ResourceData, m interface{}) (lib.Cluste
 			n,
 		},
 		KubernetesConfig:   kubernetesConfig,
-		MultiNodeRequested: false,
+		MultiNodeRequested: multiNode,
 		StaticIP:           d.Get("static_ip").(string),
 	}
 
@@ -397,7 +404,7 @@ func initialiseMinikubeClient(d *schema.ResourceData, m interface{}) (lib.Cluste
 		Addons:          addonStrings,
 		IsoUrls:         state_utils.ReadSliceState(defaultIsos),
 		DeleteOnFailure: d.Get("delete_on_failure").(bool),
-		Nodes:           d.Get("nodes").(int),
+		Nodes:           nodes,
 		NativeSsh:       d.Get("native_ssh").(bool),
 	})
 

--- a/minikube/resource_cluster.go
+++ b/minikube/resource_cluster.go
@@ -191,7 +191,6 @@ func setClusterState(d *schema.ResourceData, config *config.ClusterConfig, ports
 	d.Set("namespace", config.KubernetesConfig.Namespace)
 	d.Set("nat_nic_type", config.NatNicType)
 	d.Set("network", config.Network)
-	d.Set("network_plugin", config.KubernetesConfig.NetworkPlugin)
 	d.Set("nfs_share", state_utils.SliceOrNil(config.NFSShare))
 	d.Set("nfs_shares_root", config.NFSSharesRoot)
 	d.Set("no_vtx_check", config.NoVTXCheck)

--- a/minikube/resource_cluster.go
+++ b/minikube/resource_cluster.go
@@ -239,6 +239,8 @@ func initialiseMinikubeClient(d *schema.ResourceData, m interface{}) (lib.Cluste
 		return nil, err
 	}
 
+	driver := d.Get("driver").(string)
+
 	addons, ok := d.GetOk("addons")
 	if !ok {
 		addons = &schema.Set{}
@@ -295,6 +297,11 @@ func initialiseMinikubeClient(d *schema.ResourceData, m interface{}) (lib.Cluste
 		}
 	}
 
+	containerRuntime := d.Get("container_runtime").(string)
+	if containerRuntime == "" {
+		containerRuntime = driver
+	}
+
 	k8sVersion := clusterClient.GetK8sVersion()
 	kubernetesConfig := config.KubernetesConfig{
 		KubernetesVersion:      k8sVersion,
@@ -304,7 +311,7 @@ func initialiseMinikubeClient(d *schema.ResourceData, m interface{}) (lib.Cluste
 		APIServerNames:         apiserverNames,
 		DNSDomain:              d.Get("dns_domain").(string),
 		FeatureGates:           d.Get("feature_gates").(string),
-		ContainerRuntime:       d.Get("container_runtime").(string),
+		ContainerRuntime:       containerRuntime,
 		CRISocket:              d.Get("cri_socket").(string),
 		NetworkPlugin:          d.Get("network_plugin").(string),
 		ServiceCIDR:            d.Get("service_cluster_ip_range").(string),
@@ -319,7 +326,7 @@ func initialiseMinikubeClient(d *schema.ResourceData, m interface{}) (lib.Cluste
 		Name:              "",
 		Port:              8443,
 		KubernetesVersion: k8sVersion,
-		ContainerRuntime:  d.Get("container_runtime").(string),
+		ContainerRuntime:  containerRuntime,
 		ControlPlane:      true,
 		Worker:            true,
 	}
@@ -347,7 +354,7 @@ func initialiseMinikubeClient(d *schema.ResourceData, m interface{}) (lib.Cluste
 		Memory:                  memoryMb,
 		CPUs:                    d.Get("cpus").(int),
 		DiskSize:                diskMb,
-		Driver:                  d.Get("driver").(string),
+		Driver:                  driver,
 		ListenAddress:           d.Get("listen_address").(string),
 		HyperkitVpnKitSock:      d.Get("hyperkit_vpnkit_sock").(string),
 		HyperkitVSockPorts:      state_utils.ReadSliceState(hyperKitSockPorts),

--- a/minikube/resource_cluster.go
+++ b/minikube/resource_cluster.go
@@ -240,6 +240,7 @@ func initialiseMinikubeClient(d *schema.ResourceData, m interface{}) (lib.Cluste
 	}
 
 	driver := d.Get("driver").(string)
+	containerRuntime := d.Get("container_runtime").(string)
 
 	addons, ok := d.GetOk("addons")
 	if !ok {
@@ -295,11 +296,6 @@ func initialiseMinikubeClient(d *schema.ResourceData, m interface{}) (lib.Cluste
 		if err := extraConfigs.Set(e); err != nil {
 			return nil, fmt.Errorf("invalid extra option: %s: %v", e, err)
 		}
-	}
-
-	containerRuntime := d.Get("container_runtime").(string)
-	if containerRuntime == "" {
-		containerRuntime = driver
 	}
 
 	k8sVersion := clusterClient.GetK8sVersion()

--- a/minikube/schema_cluster.go
+++ b/minikube/schema_cluster.go
@@ -190,12 +190,12 @@ var (
 	
 		"container_runtime": {
 			Type:					schema.TypeString,
-			Description:	"The container runtime to be used. Valid options: docker, cri-o, containerd (default: auto)",
+			Description:	"The container runtime to be used. Valid options: docker, cri-o, containerd (default: docker)",
 			
 			Optional:			true,
 			ForceNew:			true,
 			
-			Default:	"",
+			Default:	"docker",
 		},
 	
 		"cpus": {


### PR DESCRIPTION
Fixes https://github.com/scott-the-programmer/terraform-provider-minikube/issues/131

Currently, setting up multiple nodes with cni=auto exhibits inconsistent behaviour due to not providing enough information to [chooseDefault](https://github.com/kubernetes/minikube/blob/37eeaddf7ad63a7f690129247650e8dd4ff3d56a/pkg/minikube/cni/cni.go#L126-L165) function in minikube. 

There's 3 key pieces we're missing

A) the container runtime, which should default to docker (previously blank)
B) `MultiNodeRequested` = true when multiple nodes are configured
C) not defaulting `network_plugin` correctly 

This allows the downstream defaults to work correctly, likely configuring `kindnet` for multi node clusters.

TODO:

- [ ] Run integration tests locally
- [ ] Test a few driver variants (kvm2, docker, hyperkit, hyperv)