### PR TITLE
fix multi-node clusters from not applying addons on first apply

### DIFF
--- a/minikube/lib/minikube_client.go
+++ b/minikube/lib/minikube_client.go
@@ -188,6 +188,8 @@ func (e *MinikubeClient) Start() (*kubeconfig.Settings, error) {
 
 	klog.Flush()
 
+	e.setAddons(e.addons, true)
+
 	return kc, nil
 }
 

--- a/minikube/lib/minikube_client_test.go
+++ b/minikube/lib/minikube_client_test.go
@@ -762,6 +762,11 @@ func getNodeSuccess(ctrl *gomock.Controller) Cluster {
 		Start(gomock.Any(), true).
 		Return(nil, nil)
 
+	nRunnerSuccess.EXPECT().
+		SetAddon(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
 	return nRunnerSuccess
 }
 
@@ -780,6 +785,11 @@ func getMultipleNodesSuccess(ctrl *gomock.Controller, n int) Cluster {
 		Add(gomock.Any(), gomock.Any()).
 		Return(nil).
 		Times(n - 1)
+
+	nRunnerSuccess.EXPECT().
+		SetAddon(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
 
 	return nRunnerSuccess
 }

--- a/minikube/resource_cluster_test.go
+++ b/minikube/resource_cluster_test.go
@@ -77,6 +77,21 @@ func TestClusterCreation_Docker(t *testing.T) {
 	})
 }
 
+func TestClusterCreation_Docker_Multinode(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers:    map[string]*schema.Provider{"minikube": Provider()},
+		CheckDestroy: verifyDelete,
+		Steps: []resource.TestStep{
+			{
+				Config: testAcceptanceClusterConfigMultiNode("docker", "TestClusterCreationDocker"),
+				Check: resource.ComposeTestCheckFunc(
+					testPropertyExists("minikube_cluster.new", "TestClusterCreationDocker"),
+				),
+			},
+		},
+	})
+}
+
 func TestClusterCreation_Docker_ExtraConfig(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		Providers:    map[string]*schema.Provider{"minikube": Provider()},
@@ -451,6 +466,25 @@ func testAcceptanceClusterConfig(driver string, clusterName string) string {
 			"default-storageclass",
 			"storage-provisioner",
 		]
+	}
+	`, driver, clusterName)
+}
+
+func testAcceptanceClusterConfigMultiNode(driver string, clusterName string) string {
+	return fmt.Sprintf(`
+	resource "minikube_cluster" "new" {
+		driver = "%s"
+		cluster_name = "%s"
+		cpus = 2 
+		memory = "6GiB"
+
+		addons = [
+			"dashboard",
+			"default-storageclass",
+			"storage-provisioner",
+		]
+
+		nodes = 3
 	}
 	`, driver, clusterName)
 }

--- a/minikube/resource_cluster_test.go
+++ b/minikube/resource_cluster_test.go
@@ -77,21 +77,6 @@ func TestClusterCreation_Docker(t *testing.T) {
 	})
 }
 
-func TestClusterCreation_Docker_Multinode(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		Providers:    map[string]*schema.Provider{"minikube": Provider()},
-		CheckDestroy: verifyDelete,
-		Steps: []resource.TestStep{
-			{
-				Config: testAcceptanceClusterConfigMultiNode("docker", "TestClusterCreationDocker"),
-				Check: resource.ComposeTestCheckFunc(
-					testPropertyExists("minikube_cluster.new", "TestClusterCreationDocker"),
-				),
-			},
-		},
-	})
-}
-
 func TestClusterCreation_Docker_ExtraConfig(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		Providers:    map[string]*schema.Provider{"minikube": Provider()},
@@ -466,25 +451,6 @@ func testAcceptanceClusterConfig(driver string, clusterName string) string {
 			"default-storageclass",
 			"storage-provisioner",
 		]
-	}
-	`, driver, clusterName)
-}
-
-func testAcceptanceClusterConfigMultiNode(driver string, clusterName string) string {
-	return fmt.Sprintf(`
-	resource "minikube_cluster" "new" {
-		driver = "%s"
-		cluster_name = "%s"
-		cpus = 2 
-		memory = "6GiB"
-
-		addons = [
-			"dashboard",
-			"default-storageclass",
-			"storage-provisioner",
-		]
-
-		nodes = 3
 	}
 	`, driver, clusterName)
 }


### PR DESCRIPTION
It appears that addons are no longer being applied on the initial creation, causing apparent drift on a recreation. This appears to only affect multi-node clusters

```terraform
resource "minikube_cluster" "docker" {
  driver       = "docker"
  cluster_name = "terraform-provider-minikube-acc-docker"
  addons = [
    "default-storageclass",
    "storage-provisioner"
  ]
  
  nodes = 3
}
````

The re-apply will create the addons, fixing any more subsequent drifts. A better approach would be to apply the addons after the cluster has been created, rather than relying on runner provisioner to do it for us 