### PR TITLE
fix case where cli option is prefixed with a short alias

### DIFF
--- a/minikube/generator/schema_builder.go
+++ b/minikube/generator/schema_builder.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -159,14 +160,21 @@ func (s *SchemaBuilder) Build() (string, error) {
 
 	currentEntry := SchemaEntry{}
 
+	pattern := "^-[a-zA-Z], "
+
+	srg := regexp.MustCompile(pattern)
+
 	for scanner.Scan() {
 		line := scanner.Text()
 		line = strings.TrimSpace(line)
 
+		// trim the short parameter e.g. -g
+		line = srg.ReplaceAllString(line, "")
+
 		if strings.HasPrefix(line, "--") {
 			currentEntry = loadParameter(line)
 		} else if line != "" {
-			if currentEntry.Description != "" { // Let's readd a space between line blocks
+			if currentEntry.Description != "" { // Let's read a space between line blocks
 				currentEntry.Description += " "
 			}
 			currentEntry.Description += line

--- a/minikube/generator/schema_builder.go
+++ b/minikube/generator/schema_builder.go
@@ -314,14 +314,6 @@ var (
 			Default:			"terraform-provider-minikube",
 		},
 
-		"nodes": {
-			Type:					schema.TypeInt,
-			Optional:			true,
-			ForceNew:			true,
-			Description:	"Amount of nodes in the cluster",
-			Default:			1,
-		},
-
 		"client_key": {
 			Type:        schema.TypeString,
 			Computed:    true,

--- a/minikube/generator/schema_builder_test.go
+++ b/minikube/generator/schema_builder_test.go
@@ -111,6 +111,38 @@ func GetClusterSchema() map[string]*schema.Schema {
 	`, schema)
 }
 
+func TestAliasProperty(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockMinikube := NewMockMinikubeBinary(ctrl)
+	mockMinikube.EXPECT().GetVersion(gomock.Any()).Return("Version 999", nil)
+	mockMinikube.EXPECT().GetStartHelpText(gomock.Any()).Return(`
+-t, --test='test-value':
+	I am a great test description
+
+	`, nil)
+	builder := NewSchemaBuilder("fake.go", mockMinikube)
+	schema, err := builder.Build()
+	assert.NoError(t, err)
+	assert.Equal(t, header+`
+		"test": {
+			Type:					schema.TypeString,
+			Description:	"I am a great test description",
+			
+			Optional:			true,
+			ForceNew:			true,
+			
+			Default:	"test-value",
+		},
+	
+	}
+)
+
+func GetClusterSchema() map[string]*schema.Schema {
+	return clusterSchema
+}
+	`, schema)
+}
+
 func TestMultilineDescription(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockMinikube := NewMockMinikubeBinary(ctrl)

--- a/minikube/generator/schema_builder_test.go
+++ b/minikube/generator/schema_builder_test.go
@@ -31,14 +31,6 @@ var (
 			Default:			"terraform-provider-minikube",
 		},
 
-		"nodes": {
-			Type:					schema.TypeInt,
-			Optional:			true,
-			ForceNew:			true,
-			Description:	"Amount of nodes in the cluster",
-			Default:			1,
-		},
-
 		"client_key": {
 			Type:        schema.TypeString,
 			Computed:    true,

--- a/minikube/resource_cluster.go
+++ b/minikube/resource_cluster.go
@@ -407,6 +407,7 @@ func initialiseMinikubeClient(d *schema.ResourceData, m interface{}) (lib.Cluste
 		KubernetesConfig:   kubernetesConfig,
 		MultiNodeRequested: multiNode,
 		StaticIP:           d.Get("static_ip").(string),
+		GPUs:               d.Get("gpus").(string),
 	}
 
 	clusterClient.SetConfig(lib.MinikubeClientConfig{

--- a/minikube/schema_cluster.go
+++ b/minikube/schema_cluster.go
@@ -417,6 +417,16 @@ var (
 			Default:	false,
 		},
 	
+		"gpus": {
+			Type:					schema.TypeString,
+			Description:	"Allow pods to use your NVIDIA GPUs. Options include: [all,nvidia] (Docker driver with Docker container-runtime only)",
+			
+			Optional:			true,
+			ForceNew:			true,
+			
+			Default:	"",
+		},
+	
 		"host_dns_resolver": {
 			Type:					schema.TypeBool,
 			Description:	"Enable host resolver for NAT DNS requests (virtualbox driver only)",
@@ -871,6 +881,26 @@ var (
 			ForceNew:			true,
 			
 			Default:	false,
+		},
+	
+		"nodes": {
+			Type:					schema.TypeInt,
+			Description:	"The number of nodes to spin up. Defaults to 1.",
+			
+			Optional:			true,
+			ForceNew:			true,
+			
+			Default:	1,
+		},
+	
+		"output": {
+			Type:					schema.TypeString,
+			Description:	"Format to print stdout in. Options include: [text,json]",
+			
+			Optional:			true,
+			ForceNew:			true,
+			
+			Default:	"text",
 		},
 	
 		"ports": {

--- a/minikube/schema_cluster.go
+++ b/minikube/schema_cluster.go
@@ -21,14 +21,6 @@ var (
 			Default:			"terraform-provider-minikube",
 		},
 
-		"nodes": {
-			Type:					schema.TypeInt,
-			Optional:			true,
-			ForceNew:			true,
-			Description:	"Amount of nodes in the cluster",
-			Default:			1,
-		},
-
 		"client_key": {
 			Type:        schema.TypeString,
 			Computed:    true,


### PR DESCRIPTION
Fixes https://github.com/scott-the-programmer/terraform-provider-minikube/issues/135

Turns out that the --gpu flag was being ignored as it was prefixed with a -g. This is the only meaningful usage of the short alias, so it went unnoticed. 

The fix is to trim any short aliases before transforming the flag into the terraform equivalent