### PR TITLE
Minor bump to provider default to match version in the examples / docs

### DIFF
--- a/minikube/provider.go
+++ b/minikube/provider.go
@@ -29,7 +29,7 @@ func NewProvider(providerConfigure schema.ConfigureContextFunc) *schema.Provider
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "The Kubernetes version that the minikube VM will use. Defaults to 'stable'.",
-				Default:     "v1.26.3",
+				Default:     "v1.28.3",
 			},
 		},
 	}


### PR DESCRIPTION
Minor bump to provider default to match version in the examples / docs