### PR TITLE
add socket_vmnet defaults for darwin amd/arm

### DIFF
--- a/minikube/generator/schema_builder.go
+++ b/minikube/generator/schema_builder.go
@@ -100,6 +100,32 @@ var schemaOverrides map[string]SchemaOverride = map[string]SchemaOverride{
 		Description: "A set of key=value pairs that describe configuration that may be passed to different components. 		The key should be '.' separated, and the first part before the dot is the component to apply the configuration to. 		Valid components are: kubelet, kubeadm, apiserver, controller-manager, etcd, proxy, scheduler 		Valid kubeadm parameters: ignore-preflight-errors, dry-run, kubeconfig, kubeconfig-dir, node-name, cri-socket, experimental-upload-certs, certificate-key, rootfs, skip-phases, pod-network-cidr",
 		Type:        Array,
 	},
+	"socket_vmnet_path": {
+		Description: "Path to socket vmnet binary (QEMU driver only)",
+		Type:        String,
+		DefaultFunc: `func() (any, error) {
+        var prefix string
+        if runtime.GOARCH == "arm64" {
+            prefix = "/opt/homebrew"
+        } else {
+            prefix = "/usr/local"
+        }
+        return prefix + "/var/run/socket_vmnet", nil
+    }`,
+	},
+	"socket_vmnet_client_path": {
+		Description: "Path to the socket vmnet client binary (QEMU driver only)",
+		Type:        String,
+		DefaultFunc: `func() (any, error) {
+        var prefix string
+        if runtime.GOARCH == "arm64" {
+            prefix = "/opt/homebrew"
+        } else {
+            prefix = "/usr/local"
+        }
+        return prefix + "/opt/socket_vmnet/bin/socket_vmnet_client", nil
+    }`,
+	},
 }
 
 func run(ctx context.Context, args ...string) (string, error) {

--- a/minikube/resource_cluster.go
+++ b/minikube/resource_cluster.go
@@ -404,10 +404,12 @@ func initialiseMinikubeClient(d *schema.ResourceData, m interface{}) (lib.Cluste
 		Nodes: []config.Node{
 			n,
 		},
-		KubernetesConfig:   kubernetesConfig,
-		MultiNodeRequested: multiNode,
-		StaticIP:           d.Get("static_ip").(string),
-		GPUs:               d.Get("gpus").(string),
+		KubernetesConfig:      kubernetesConfig,
+		MultiNodeRequested:    multiNode,
+		StaticIP:              d.Get("static_ip").(string),
+		GPUs:                  d.Get("gpus").(string),
+		SocketVMnetPath:       d.Get("socket_vmnet_path").(string),
+		SocketVMnetClientPath: d.Get("socket_vmnet_client_path").(string),
 	}
 
 	clusterClient.SetConfig(lib.MinikubeClientConfig{

--- a/minikube/resource_cluster_test.go
+++ b/minikube/resource_cluster_test.go
@@ -197,6 +197,26 @@ func TestClusterCreation_Hyperkit(t *testing.T) {
 	})
 }
 
+func TestClusterCreation_QemuSocketVmNet(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("Hyperkit is only supported on macOS")
+		return
+	}
+
+	resource.Test(t, resource.TestCase{
+		Providers:    map[string]*schema.Provider{"minikube": Provider()},
+		CheckDestroy: verifyDelete,
+		Steps: []resource.TestStep{
+			{
+				Config: testAcceptanceClusterConfigQemuSocketVmNet("qemu2", "TestClusterCreationQemu"),
+				Check: resource.ComposeTestCheckFunc(
+					testPropertyExists("minikube_cluster.new", "TestClusterCreationQemu"),
+				),
+			},
+		},
+	})
+}
+
 func TestClusterCreation_HyperV(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("HyperV is only supported on windows")
@@ -466,6 +486,18 @@ func testAcceptanceClusterConfig(driver string, clusterName string) string {
 			"default-storageclass",
 			"storage-provisioner",
 		]
+	}
+	`, driver, clusterName)
+}
+
+func testAcceptanceClusterConfigQemuSocketVmNet(driver string, clusterName string) string {
+	return fmt.Sprintf(`
+	resource "minikube_cluster" "new" {
+		driver = "%s"
+		cluster_name = "%s"
+
+		network = "socket_vmnet"
+
 	}
 	`, driver, clusterName)
 }

--- a/minikube/schema_cluster.go
+++ b/minikube/schema_cluster.go
@@ -962,7 +962,15 @@ var (
 			Optional:			true,
 			ForceNew:			true,
 			
-			Default:	"",
+			DefaultFunc:	func() (any, error) {
+        var prefix string
+        if runtime.GOARCH == "arm64" {
+            prefix = "/opt/homebrew"
+        } else {
+            prefix = "/usr/local"
+        }
+        return prefix + "/opt/socket_vmnet/bin/socket_vmnet_client", nil
+    },
 		},
 	
 		"socket_vmnet_path": {
@@ -972,7 +980,15 @@ var (
 			Optional:			true,
 			ForceNew:			true,
 			
-			Default:	"",
+			DefaultFunc:	func() (any, error) {
+        var prefix string
+        if runtime.GOARCH == "arm64" {
+            prefix = "/opt/homebrew"
+        } else {
+            prefix = "/usr/local"
+        }
+        return prefix + "/var/run/socket_vmnet", nil
+    },
 		},
 	
 		"ssh_ip_address": {


### PR DESCRIPTION
Fixes https://github.com/scott-the-programmer/terraform-provider-minikube/issues/132

Adds defaults for `socket_vmnet_path` and `socket_vmnet_client_path` based on the socket_vmnet [readme](https://github.com/lima-vm/socket_vmnet?tab=readme-ov-file#install) 

>The binaries will be installed onto the following paths:
${HOMEBREW_PREFIX}/opt/socket_vmnet/bin/socket_vmnet
${HOMEBREW_PREFIX}/opt/socket_vmnet/bin/socket_vmnet_client
The ${HOMEBREW_PREFIX} path defaults to /opt/homebrew on ARM, /usr/local on Intel.

this will then allow

```terraform
resource "minikube_cluster" "default" {
  cluster_name          = "minikube"
  driver                = "qemu2"
  network               = "socket_vmnet"
}
```