### PR TITLE
bump go version to 1.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.21'
+        go-version: '1.23'
 
     - name: Install prerequisites
       run: make init

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/scott-the-programmer/terraform-provider-minikube
 
-go 1.22.7
+go 1.23.0
+
 toolchain go1.24.1
 
 require (


### PR DESCRIPTION
This pull request includes updates to the Go version used in the project configuration files.

Version updates:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL19-R19): Updated the Go version from `1.21` to `1.23` in the CI workflow setup.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R4): Updated the Go version from `1.22.7` to `1.23.0` and added a toolchain specification for `go1.24.1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded the programming language version used in the build process.
  - Updated the build environment’s toolchain settings to enhance performance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->