### PR TITLE
Upgrade to minikube 1.36

### DIFF
--- a/bootstrap/install-driver.sh
+++ b/bootstrap/install-driver.sh
@@ -2,7 +2,7 @@
 
 set -e 
 
-VERSION="v1.34.0"
+VERSION="v1.36.0"
 
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
 

--- a/examples/guides/terragrunt/terragrunt_project/_envcommon/minikube.hcl
+++ b/examples/guides/terragrunt/terragrunt_project/_envcommon/minikube.hcl
@@ -1,7 +1,7 @@
 locals {
   base_source_url    = "git::https://github.com/scott-the-programmer/terraform-provider-minikube.git//examples/guides/terragrunt/terraform_project"
   ref                = "main"
-  kubernetes_version = "v1.28.3"
+  kubernetes_version = "v1.30.2"
 }
 
 generate "provider" {

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,3 +1,3 @@
 provider "minikube" {
-  kubernetes_version = "v1.30.0"
+  kubernetes_version = "v1.30.2"
 }

--- a/examples/resources/minikube_cluster/resource.tf
+++ b/examples/resources/minikube_cluster/resource.tf
@@ -1,5 +1,5 @@
 provider "minikube" {
-  kubernetes_version = "v1.30.0"
+  kubernetes_version = "v1.30.2"
 }
 
 resource "minikube_cluster" "docker" {

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
 	k8s.io/klog/v2 v2.130.1
-	k8s.io/minikube v1.34.0
+	k8s.io/minikube v1.35.0
 )
 
 replace (

--- a/minikube/schema_cluster.go
+++ b/minikube/schema_cluster.go
@@ -137,7 +137,7 @@ var (
 			Optional:			true,
 			ForceNew:			true,
 			
-			Default:	"gcr.io/k8s-minikube/kicbase:v0.0.45@sha256:81df288595202a317b1a4dc2506ca2e4ed5f22373c19a441b88cfbf4b9867c85",
+			Default:	"gcr.io/k8s-minikube/kicbase:v0.0.46@sha256:fd2d445ddcc33ebc5c6b68a17e6219ea207ce63c005095ea1525296da2d1a279",
 		},
 	
 		"binary_mirror": {
@@ -415,7 +415,7 @@ var (
 	
 		"gpus": {
 			Type:					schema.TypeString,
-			Description:	"Allow pods to use your NVIDIA GPUs. Options include: [all,nvidia] (Docker driver with Docker container-runtime only)",
+			Description:	"Allow pods to use your GPUs. Options include: [all,nvidia,amd] (Docker driver with Docker container-runtime only)",
 			
 			Optional:			true,
 			ForceNew:			true,
@@ -600,7 +600,7 @@ var (
 	
 		"kubernetes_version": {
 			Type:					schema.TypeString,
-			Description:	"The Kubernetes version that the minikube VM will use (ex: v1.2.3, 'stable' for v1.31.0, 'latest' for v1.31.0). Defaults to 'stable'.",
+			Description:	"The Kubernetes version that the minikube VM will use (ex: v1.2.3, 'stable' for v1.32.0, 'latest' for v1.32.0). Defaults to 'stable'.",
 			
 			Optional:			true,
 			ForceNew:			true,

--- a/minikube/schema_cluster.go
+++ b/minikube/schema_cluster.go
@@ -137,7 +137,7 @@ var (
 			Optional:			true,
 			ForceNew:			true,
 			
-			Default:	"gcr.io/k8s-minikube/kicbase:v0.0.46@sha256:fd2d445ddcc33ebc5c6b68a17e6219ea207ce63c005095ea1525296da2d1a279",
+			Default:	"gcr.io/k8s-minikube/kicbase:v0.0.47@sha256:6ed579c9292b4370177b7ef3c42cc4b4a6dcd0735a1814916cbc22c8bf38412b",
 		},
 	
 		"binary_mirror": {
@@ -375,7 +375,7 @@ var (
 	
 		"extra_disks": {
 			Type:					schema.TypeInt,
-			Description:	"Number of extra disks created and attached to the minikube VM (currently only implemented for hyperkit, kvm2, and qemu2 drivers)",
+			Description:	"Number of extra disks created and attached to the minikube VM (currently only implemented for hyperkit, kvm2, qemu2, and vfkit drivers)",
 			
 			Optional:			true,
 			ForceNew:			true,
@@ -600,7 +600,7 @@ var (
 	
 		"kubernetes_version": {
 			Type:					schema.TypeString,
-			Description:	"The Kubernetes version that the minikube VM will use (ex: v1.2.3, 'stable' for v1.32.0, 'latest' for v1.32.0). Defaults to 'stable'.",
+			Description:	"The Kubernetes version that the minikube VM will use (ex: v1.2.3, 'stable' for v1.33.1, 'latest' for v1.33.1). Defaults to 'stable'.",
 			
 			Optional:			true,
 			ForceNew:			true,
@@ -826,7 +826,7 @@ var (
 	
 		"network": {
 			Type:					schema.TypeString,
-			Description:	"network to run minikube with. Now it is used by docker/podman and KVM drivers. If left empty, minikube will create a new network.",
+			Description:	"network to run minikube with. Used by docker/podman, qemu, kvm, and vfkit drivers. If left empty, minikube will create a new network.",
 			
 			Optional:			true,
 			ForceNew:			true,
@@ -1107,7 +1107,7 @@ var (
 	
 		"wait": {
 			Type:					schema.TypeSet,
-			Description:	"comma separated list of Kubernetes components to verify and wait for after starting a cluster. defaults to \"apiserver,system_pods\", available options: \"apiserver,system_pods,default_sa,apps_running,node_ready,kubelet\" . other acceptable values are 'all' or 'none', 'true' and 'false'",
+			Description:	"comma separated list of Kubernetes components to verify and wait for after starting a cluster. defaults to \"apiserver,system_pods\", available options: \"apiserver,system_pods,default_sa,apps_running,node_ready,kubelet,extra\" . other acceptable values are 'all' or 'none', 'true' and 'false'",
 			
 			Optional:			true,
 			ForceNew:			true,

--- a/minikube/version/version.go
+++ b/minikube/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 const (
-	Version = "v1.34.0" //	matches k8s.io/minikube v1.34.0
+	Version = "v1.35.0" //	matches k8s.io/minikube v1.35.0
 )

--- a/minikube/version/version.go
+++ b/minikube/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 const (
-	Version = "v1.35.0" //	matches k8s.io/minikube v1.35.0
+	Version = "v1.36.0" //	matches k8s.io/minikube v1.36.0
 )


### PR DESCRIPTION
This pull request includes updates to version numbers, container image references, and descriptions for various features in the Minikube configuration schema. These changes ensure compatibility with the latest releases and expand support for additional drivers and features.

### Version Updates:
* Updated the Minikube version from `v1.35.0` to `v1.36.0` in `minikube/version/version.go` to match the latest release.
* Updated the driver installation script to use version `v1.36.0` instead of `v1.34.0` in `bootstrap/install-driver.sh`.

### Container Image Updates:
* Updated the default container image for Minikube from `kicbase:v0.0.46` to `kicbase:v0.0.47` in `minikube/schema_cluster.go`.

### Schema Description Updates:
* Expanded the description for the `extra_disks` field to include support for the `vfkit` driver in `minikube/schema_cluster.go`.
* Updated the description of the `network` field to include the `vfkit` and `qemu` drivers in `minikube/schema_cluster.go`.
* Added `extra` as a new option for Kubernetes components in the `wait` field description in `minikube/schema_cluster.go`.

### Kubernetes Version Update:
* Updated the Kubernetes version examples in the `kubernetes_version` field description to reflect the latest stable version (`v1.33.1`) in `minikube/schema_cluster.go`.