### PR TITLE
apiserver_ips not applied to API server certificate SANs when using docker driver

### DIFF
--- a/minikube/generator/schema_builder.go
+++ b/minikube/generator/schema_builder.go
@@ -32,7 +32,6 @@ func (m *MinikubeHostBinary) GetStartHelpText(ctx context.Context) (string, erro
 }
 
 var computedFields []string = []string{
-	"apiserver_ips",
 	"apiserver_names",
 	"hyperkit_vsock_ports",
 	"insecure_registry",

--- a/minikube/resource_cluster.go
+++ b/minikube/resource_cluster.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"sort"
 	"strconv"
 	"time"
@@ -293,6 +294,13 @@ func initialiseMinikubeClient(d *schema.ResourceData, m interface{}) (lib.Cluste
 		apiserverNames = state_utils.ReadSliceState(d.Get("apiserver_names"))
 	}
 
+	var apiServerIPs []net.IP
+	if v, ok := d.GetOk("apiserver_ips"); ok {
+		for _, ip := range v.(*schema.Set).List() {
+			apiServerIPs = append(apiServerIPs, net.ParseIP(ip.(string)))
+		}
+	}
+
 	apiserverPort := d.Get("apiserver_port").(int)
 
 	networkPlugin := d.Get("network_plugin").(string) // This is a deprecated parameter in Minikube, however,
@@ -322,6 +330,7 @@ func initialiseMinikubeClient(d *schema.ResourceData, m interface{}) (lib.Cluste
 		Namespace:              d.Get("namespace").(string),
 		APIServerName:          d.Get("apiserver_name").(string),
 		APIServerNames:         apiserverNames,
+		APIServerIPs:           apiServerIPs,
 		DNSDomain:              d.Get("dns_domain").(string),
 		FeatureGates:           d.Get("feature_gates").(string),
 		ContainerRuntime:       containerRuntime,


### PR DESCRIPTION
This PR addresses a bug when using the docker driver with apiserver_ips.

Even when apiserver_ips is configured in Terraform, the specified IPs are not added to the Kubernetes API server certificate SANs. As a result, clients connecting via the configured IP hit TLS validation errors (x509: certificate is valid for … not <LAN-IP>).

**Problem**

Example Terraform config:

```yml
resource "minikube_cluster" "docker" {
  driver        = "docker"
  cluster_name  = "terraform-provider-minikube-docker"
  apiserver_ips = ["192.168.100.82"]
  ...
}
```

**Running**
```bash
minikube -p terraform-provider-minikube-docker ssh -- \
  "sudo openssl x509 -noout -text -in /var/lib/minikube/certs/apiserver.crt | grep -A1 'Subject Alternative Name'"
```

**Actual result (missing 192.168.100.82)**

the IPs do not appear in the Kubernetes API server certificate SAN
```bash
X509v3 Subject Alternative Name: 
    DNS:kubernetes.local, DNS:minikubeCA, DNS:control-plane.minikube.internal, DNS:terraform-provider-minikube-docker,
    DNS:kubernetes.default.svc.cluster.local, DNS:kubernetes.default.svc, DNS:kubernetes.default, DNS:kubernetes,
    DNS:localhost, IP Address:10.96.0.1, IP Address:127.0.0.1, IP Address:10.0.0.1, IP Address:192.168.49.2

```
**Expected result (with 192.168.100.82 included)**
```bash
X509v3 Subject Alternative Name: 
    DNS:kubernetes.local, DNS:minikubeCA, DNS:control-plane.minikube.internal, DNS:terraform-provider-minikube-docker,
    DNS:kubernetes.default.svc.cluster.local, DNS:kubernetes.default.svc, DNS:kubernetes.default, DNS:kubernetes,
    DNS:localhost, IP Address:192.168.100.82, IP Address:10.96.0.1, IP Address:127.0.0.1, IP Address:10.0.0.1, IP Address:192.168.49.2
````

**Context**

This issue occurs only via the Terraform provider.

Running minikube start --apiserver-ips=192.168.100.82 directly works as expected and adds the IP to SANs.

The provider currently doesn’t propagate apiserver_ips to the underlying minikube/kubeadm configuration, which causes the mismatch.