### PR TITLE
Fix default networking for QEMU clusters

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -49,7 +49,7 @@ provider "kubernetes" {
 }
 
 
-resource "kubernetes_deployment" "deployment" {
+resource "kubernetes_deployment_v1" "deployment" {
   metadata {
     name = "nginx-example"
     labels = {

--- a/examples/resources/minikube_cluster/resource.tf
+++ b/examples/resources/minikube_cluster/resource.tf
@@ -34,7 +34,7 @@ provider "kubernetes" {
 }
 
 
-resource "kubernetes_deployment" "deployment" {
+resource "kubernetes_deployment_v1" "deployment" {
   metadata {
     name = "nginx-example"
     labels = {

--- a/minikube/resource_cluster.go
+++ b/minikube/resource_cluster.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"k8s.io/minikube/pkg/minikube/config"
+	minikubeDriver "k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/kubeconfig"
 	pkgutil "k8s.io/minikube/pkg/util"
 )
@@ -22,6 +23,14 @@ import (
 var (
 	defaultIso = lib.GetMinikubeIso()
 )
+
+func resolveNetwork(driver, network string) string {
+	if minikubeDriver.IsQEMU(driver) && network == "" {
+		return "builtin"
+	}
+
+	return network
+}
 
 func ResourceCluster() *schema.Resource {
 	return &schema.Resource{
@@ -240,6 +249,7 @@ func initialiseMinikubeClient(d *schema.ResourceData, m interface{}) (lib.Cluste
 
 	driver := d.Get("driver").(string)
 	containerRuntime := d.Get("container_runtime").(string)
+	network := resolveNetwork(driver, d.Get("network").(string))
 
 	addons, ok := d.GetOk("addons")
 	if !ok {
@@ -387,7 +397,7 @@ func initialiseMinikubeClient(d *schema.ResourceData, m interface{}) (lib.Cluste
 		EmbedCerts:              d.Get("embed_certs").(bool),
 		MinikubeISO:             state_utils.ReadSliceState(defaultIsos)[0],
 		KicBaseImage:            d.Get("base_image").(string),
-		Network:                 d.Get("network").(string),
+		Network:                 network,
 		Memory:                  memoryMb,
 		CPUs:                    cpus,
 		DiskSize:                diskMb,

--- a/minikube/resource_cluster_test.go
+++ b/minikube/resource_cluster_test.go
@@ -40,6 +40,27 @@ type mockClusterClientProperties struct {
 	cpu         string
 }
 
+func TestResolveNetwork(t *testing.T) {
+	tests := []struct {
+		name    string
+		driver  string
+		network string
+		want    string
+	}{
+		{name: "QEMU default", driver: "qemu2", want: "builtin"},
+		{name: "QEMU explicit network", driver: "qemu2", network: "socket_vmnet", want: "socket_vmnet"},
+		{name: "Docker default", driver: "docker", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveNetwork(tt.driver, tt.network); got != tt.want {
+				t.Fatalf("resolveNetwork(%q, %q) = %q, want %q", tt.driver, tt.network, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestClusterCreation(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		IsUnitTest: true,


### PR DESCRIPTION
## Summary

- default an unspecified QEMU network to `builtin`, matching Minikube CLI behavior
- preserve explicitly configured QEMU networks and non-QEMU defaults
- add regression coverage for network resolution
- update the test-stack deployment and generated docs to `kubernetes_deployment_v1`

## Testing

- `make build`
- `make test`

The full Terraform test stack could not complete locally because the current user does not have access to `/var/run/docker.sock`.