### PR TITLE
Fix local provider installation and cluster example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,8 +114,12 @@ local-cli-config:
 
 .PHONY: set-local
 set-local: build local-cli-config
-	mkdir -p $(DEST_DIR)/$(OS_NAME)_$(ARCH) && \
-	cp bin/$(PLUGIN_NAME) $(DEST_DIR)/$(OS_NAME)_$(ARCH)/$(PLUGIN_NAME)$(EXT)
+	dest="$(DEST_DIR)/$(OS_NAME)_$(ARCH)/$(PLUGIN_NAME)$(EXT)"; \
+	tmp="$$dest.tmp.$$$$"; \
+	trap 'rm -f "$$tmp"' EXIT HUP INT TERM; \
+	mkdir -p "$${dest%/*}" && \
+	cp "bin/$(PLUGIN_NAME)" "$$tmp" && \
+	mv -f "$$tmp" "$$dest"
 
 .PHONY: reset-local
 reset-local:

--- a/examples/resources/minikube_cluster/resource.tf
+++ b/examples/resources/minikube_cluster/resource.tf
@@ -55,8 +55,9 @@ resource "kubernetes_deployment_v1" "deployment" {
       }
       spec {
         container {
-          image = "nginx:latest"
-          name  = "example"
+          image             = "nginx:latest"
+          image_pull_policy = "IfNotPresent"
+          name              = "example"
 
           port {
             container_port = 80

--- a/examples/resources/minikube_cluster/resource.tf
+++ b/examples/resources/minikube_cluster/resource.tf
@@ -15,8 +15,6 @@ resource "minikube_cluster" "qemu" {
   vm           = true
   driver       = "qemu2"
   cluster_name = "terraform-provider-minikube-acc-qemu"
-  nodes        = 3
-  cni          = "bridge" # Allows pods to communicate with each other via DNS
   addons = [
     "dashboard",
     "default-storageclass",

--- a/minikube/lib/minikube_cluster.go
+++ b/minikube/lib/minikube_cluster.go
@@ -129,7 +129,7 @@ func (m *MinikubeCluster) Delete(cc *config.ClusterConfig, name string) (*config
 }
 
 func (m *MinikubeCluster) SetAddon(name string, addon string, value string) error {
-	return minikubeAddons.SetAndSave(name, addon, value, nil)
+	return minikubeAddons.SetAndSave(name, addon, value, m.commandOptions)
 }
 
 func (m *MinikubeCluster) Get(name string) *config.ClusterConfig {


### PR DESCRIPTION
## Summary

- install rebuilt local provider binaries atomically so a running provider is not overwritten in place
- simplify the QEMU example and reuse an already-present nginx image
- pass the cluster command options through when configuring addons

## Testing

- `terraform fmt -check -diff examples/resources/minikube_cluster/resource.tf`
- `gofmt -d minikube/lib/minikube_cluster.go`
- `git diff --check`
- `make -n set-local`
- `GOCACHE=/tmp/terraform-provider-minikube-go-cache go test -tags libvirt_dlopen ./minikube/lib ./minikube/generator ./minikube/state_utils`

`make test` was also attempted. The package tests above passed, but nine Terraform resource tests could not start the provider in the sandbox and timed out waiting for the reattach config.