### PR TITLE
Fix repeat addon installs and multi-node cluster deletion

### DIFF
--- a/minikube/lib/minikube_client.go
+++ b/minikube/lib/minikube_client.go
@@ -200,7 +200,9 @@ func (e *MinikubeClient) Start() (*kubeconfig.Settings, error) {
 
 	klog.Flush()
 
-	e.setAddons(e.addons, true)
+	if err := e.setAddons(e.addons, true); err != nil {
+		return nil, fmt.Errorf("apply addons: %w", err)
+	}
 
 	return kc, nil
 }

--- a/minikube/lib/minikube_client_test.go
+++ b/minikube/lib/minikube_client_test.go
@@ -12,6 +12,24 @@ import (
 	_ "k8s.io/minikube/pkg/minikube/registry/drvs"
 )
 
+func TestMinikubeClientStartReportsAddonFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	runner := NewMockCluster(ctrl)
+	runner.EXPECT().Provision(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, false, nil, nil, nil)
+	runner.EXPECT().Start(gomock.Any()).Return(nil, nil)
+	wantErr := errors.New("addon installation failed")
+	runner.EXPECT().SetAddon("cluster", "dashboard", "true").Return(wantErr)
+	client := NewMinikubeClient(MinikubeClientConfig{
+		ClusterConfig: &config.ClusterConfig{Nodes: []config.Node{{}}},
+		ClusterName:   "cluster",
+		Addons:        []string{"dashboard"},
+		Nodes:         1,
+	}, MinikubeClientDeps{Node: runner, Downloader: getDownloadSuccess(ctrl)})
+	if _, err := client.Start(); !errors.Is(err, wantErr) {
+		t.Fatalf("Start() error = %v, want %v", err, wantErr)
+	}
+}
+
 func TestMinikubeClient_Start(t *testing.T) {
 	type fields struct {
 		clusterConfig   config.ClusterConfig

--- a/minikube/lib/minikube_cluster.go
+++ b/minikube/lib/minikube_cluster.go
@@ -2,6 +2,8 @@
 package lib
 
 import (
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -9,6 +11,7 @@ import (
 	minikubeAddons "k8s.io/minikube/pkg/addons"
 	"k8s.io/minikube/pkg/libmachine"
 	"k8s.io/minikube/pkg/libmachine/host"
+	"k8s.io/minikube/pkg/minikube/assets"
 	"k8s.io/minikube/pkg/minikube/command"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/exit"
@@ -61,6 +64,9 @@ func (m *MinikubeCluster) Provision(cc *config.ClusterConfig, n *config.Node, de
 }
 
 func (m *MinikubeCluster) Start(starter node.Starter) (*kubeconfig.Settings, error) {
+	if err := resetAddonAssets(); err != nil {
+		return nil, err
+	}
 	s, err := node.Start(starter, m.commandOptions)
 	if err != nil {
 		return nil, err
@@ -103,6 +109,14 @@ func (m *MinikubeCluster) AddWorkerNode(cc *config.ClusterConfig, kv string, api
 }
 
 func (m *MinikubeCluster) Delete(cc *config.ClusterConfig, name string) (*config.Node, error) {
+	// Terraform's reconstructed config only contains the primary node. Use the
+	// saved node inventory so Minikube also removes secondary nodes' volumes.
+	saved, err := config.Load(name)
+	if err == nil {
+		cc = saved
+	} else if !config.IsNotExist(err) {
+		return nil, fmt.Errorf("load cluster for deletion: %w", err)
+	}
 	errs := delete.DeleteProfiles([]*config.Profile{
 		{
 			Name:   name,
@@ -115,7 +129,7 @@ func (m *MinikubeCluster) Delete(cc *config.ClusterConfig, name string) (*config
 
 	machineDir := filepath.Join(localpath.MiniPath(), "machines", name)
 	profilesDir := filepath.Join(localpath.MiniPath(), "profiles", name)
-	err := rmdir(machineDir)
+	err = rmdir(machineDir)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +143,23 @@ func (m *MinikubeCluster) Delete(cc *config.ClusterConfig, name string) (*config
 }
 
 func (m *MinikubeCluster) SetAddon(name string, addon string, value string) error {
+	if err := resetAddonAssets(); err != nil {
+		return err
+	}
 	return minikubeAddons.SetAndSave(name, addon, value, m.commandOptions)
+}
+
+// Minikube keeps bundled addon readers globally. Unlike the CLI, a provider
+// process can install them repeatedly, so rewind them under the creation lock.
+func resetAddonAssets() error {
+	for _, addon := range assets.Addons {
+		for _, asset := range addon.Assets {
+			if _, err := asset.Seek(0, io.SeekStart); err != nil {
+				return fmt.Errorf("rewind addon asset %s: %w", asset.GetSourcePath(), err)
+			}
+		}
+	}
+	return nil
 }
 
 func (m *MinikubeCluster) Get(name string) *config.ClusterConfig {

--- a/minikube/lib/minikube_cluster_test.go
+++ b/minikube/lib/minikube_cluster_test.go
@@ -1,6 +1,40 @@
 package lib
 
-import "testing"
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"k8s.io/minikube/pkg/minikube/assets"
+)
+
+func TestResetAddonAssets(t *testing.T) {
+	asset := assets.Addons["dashboard"].Assets[0]
+	want, err := asset.ReadFile(asset.GetSourcePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 2; i++ {
+		if _, err := io.Copy(io.Discard, asset); err != nil {
+			t.Fatal(err)
+		}
+		if err := resetAddonAssets(); err != nil {
+			t.Fatal(err)
+		}
+		got, err := io.ReadAll(asset)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("installation %d: addon contents were not restored", i+1)
+		}
+	}
+	t.Cleanup(func() {
+		if err := resetAddonAssets(); err != nil {
+			t.Error(err)
+		}
+	})
+}
 
 func TestNewMinikubeClusterInitializesCommandOptions(t *testing.T) {
 	cluster := NewMinikubeCluster()

--- a/minikube/resource_cluster_test.go
+++ b/minikube/resource_cluster_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -136,9 +137,9 @@ func TestClusterCreation_Docker(t *testing.T) {
 		CheckDestroy: verifyDelete,
 		Steps: []resource.TestStep{
 			{
-				Config: testAcceptanceClusterConfig("docker", "TestClusterCreationDocker"),
+				Config: testAcceptanceClusterConfig("docker", "test-cluster-creation-docker"),
 				Check: resource.ComposeTestCheckFunc(
-					testPropertyExists("minikube_cluster.new", "TestClusterCreationDocker"),
+					testPropertyExists("minikube_cluster.new", "test-cluster-creation-docker"),
 				),
 			},
 		},
@@ -181,9 +182,9 @@ func TestClusterCreation_Docker_ExtraConfig(t *testing.T) {
 		CheckDestroy: verifyDelete,
 		Steps: []resource.TestStep{
 			{
-				Config: testAcceptanceClusterExtraConfig("docker", "TestClusterCreationDocker"),
+				Config: testAcceptanceClusterExtraConfig("docker", "test-cluster-creation-docker"),
 				Check: resource.ComposeTestCheckFunc(
-					testPropertyExists("minikube_cluster.new", "TestClusterCreationDocker"),
+					testPropertyExists("minikube_cluster.new", "test-cluster-creation-docker"),
 				),
 			},
 		},
@@ -196,13 +197,13 @@ func TestClusterCreation_Docker_Update(t *testing.T) {
 		CheckDestroy: verifyDelete,
 		Steps: []resource.TestStep{
 			{
-				Config: testAcceptanceClusterConfig("docker", "TestClusterCreationDockerUpdate"),
+				Config: testAcceptanceClusterConfig("docker", "test-cluster-creation-docker-update"),
 				Check: resource.ComposeTestCheckFunc(
-					testPropertyExists("minikube_cluster.new", "TestClusterCreationDockerUpdate"),
+					testPropertyExists("minikube_cluster.new", "test-cluster-creation-docker-update"),
 				),
 			},
 			{
-				Config: testAcceptanceClusterConfig_Update("docker", "TestClusterCreationDockerUpdate"),
+				Config: testAcceptanceClusterConfig_Update("docker", "test-cluster-creation-docker-update"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("minikube_cluster.new", "addons.2", "ingress"),
 				),
@@ -217,22 +218,22 @@ func TestClusterCreation_Docker_Addons(t *testing.T) {
 		CheckDestroy: verifyDelete,
 		Steps: []resource.TestStep{
 			{
-				Config: testAcceptanceClusterConfig_StorageProvisioner("docker", "TestClusterCreationDockerAddons"),
+				Config: testAcceptanceClusterConfig_StorageProvisioner("docker", "test-cluster-creation-docker-addons"),
 				Check: resource.ComposeTestCheckFunc(
 					func(s *terraform.State) error {
-						err := assertAddonEnabled("TestClusterCreationDockerAddons", "storage-provisioner")
+						err := assertAddonEnabled("test-cluster-creation-docker-addons", "storage-provisioner")
 						if err != nil {
 							return err
 						}
-						err = assertAddonEnabled("TestClusterCreationDockerAddons", "dashboard")
+						err = assertAddonEnabled("test-cluster-creation-docker-addons", "dashboard")
 						if err != nil {
 							return err
 						}
-						err = assertAddonEnabled("TestClusterCreationDockerAddons", "ingress")
+						err = assertAddonEnabled("test-cluster-creation-docker-addons", "ingress")
 						if err != nil {
 							return err
 						}
-						err = assertAddonEnabled("TestClusterCreationDockerAddons", "default-storageclass")
+						err = assertAddonEnabled("test-cluster-creation-docker-addons", "default-storageclass")
 						if err != nil {
 							return err
 						}
@@ -251,9 +252,9 @@ func TestClusterCreation_OutOfOrderAddons(t *testing.T) {
 		CheckDestroy: verifyDelete,
 		Steps: []resource.TestStep{
 			{
-				Config: testAcceptanceClusterConfig_OutOfOrderAddons("docker", "TestClusterCreationDocker"),
+				Config: testAcceptanceClusterConfig_OutOfOrderAddons("docker", "test-cluster-creation-docker"),
 				Check: resource.ComposeTestCheckFunc(
-					testPropertyExists("minikube_cluster.new", "TestClusterCreationDocker"),
+					testPropertyExists("minikube_cluster.new", "test-cluster-creation-docker"),
 				),
 			},
 		},
@@ -266,9 +267,9 @@ func TestClusterCreation_HAControlPlane(t *testing.T) {
 		CheckDestroy: verifyDelete,
 		Steps: []resource.TestStep{
 			{
-				Config: testAcceptanceClusterConfig_HAControlPlane("docker", "TestClusterCreationDocker"),
+				Config: testAcceptanceClusterConfig_HAControlPlane("docker", "test-cluster-creation-docker"),
 				Check: resource.ComposeTestCheckFunc(
-					testPropertyExists("minikube_cluster.new", "TestClusterCreationDocker"),
+					testPropertyExists("minikube_cluster.new", "test-cluster-creation-docker"),
 				),
 			},
 		},
@@ -281,9 +282,9 @@ func TestClusterCreation_Wait(t *testing.T) {
 		CheckDestroy: verifyDelete,
 		Steps: []resource.TestStep{
 			{
-				Config: testAcceptanceClusterConfig_Wait("docker", "TestClusterCreationDocker"),
+				Config: testAcceptanceClusterConfig_Wait("docker", "test-cluster-creation-docker"),
 				Check: resource.ComposeTestCheckFunc(
-					testPropertyExists("minikube_cluster.new", "TestClusterCreationDocker"),
+					testPropertyExists("minikube_cluster.new", "test-cluster-creation-docker"),
 				),
 			},
 		},
@@ -296,9 +297,9 @@ func TestClusterCreation_Qemu(t *testing.T) {
 		CheckDestroy: verifyDelete,
 		Steps: []resource.TestStep{
 			{
-				Config: testAcceptanceClusterConfig("qemu2", "TestClusterCreationQemu"),
+				Config: testAcceptanceClusterConfig("qemu2", "test-cluster-creation-qemu"),
 				Check: resource.ComposeTestCheckFunc(
-					testPropertyExists("minikube_cluster.new", "TestClusterCreationQemu"),
+					testPropertyExists("minikube_cluster.new", "test-cluster-creation-qemu"),
 				),
 			},
 		},
@@ -316,9 +317,9 @@ func TestClusterCreation_QemuSocketVmNet(t *testing.T) {
 		CheckDestroy: verifyDelete,
 		Steps: []resource.TestStep{
 			{
-				Config: testAcceptanceClusterConfigQemuSocketVmNet("qemu2", "TestClusterCreationQemu"),
+				Config: testAcceptanceClusterConfigQemuSocketVmNet("qemu2", "test-cluster-creation-qemu"),
 				Check: resource.ComposeTestCheckFunc(
-					testPropertyExists("minikube_cluster.new", "TestClusterCreationQemu"),
+					testPropertyExists("minikube_cluster.new", "test-cluster-creation-qemu"),
 				),
 			},
 		},
@@ -336,9 +337,9 @@ func TestClusterCreation_HyperV(t *testing.T) {
 		CheckDestroy: verifyDelete,
 		Steps: []resource.TestStep{
 			{
-				Config: testAcceptanceClusterConfig("hyperv", "TestClusterCreationHyperV"),
+				Config: testAcceptanceClusterConfig("hyperv", "test-cluster-creation-hyperv"),
 				Check: resource.ComposeTestCheckFunc(
-					testPropertyExists("minikube_cluster.new", "TestClusterCreationHyperV"),
+					testPropertyExists("minikube_cluster.new", "test-cluster-creation-hyperv"),
 				),
 			},
 		},
@@ -793,7 +794,7 @@ func testAcceptanceClusterConfig_StorageProvisioner(driver string, clusterName s
 		driver = "%s"
 		cluster_name = "%s"
 		cpus = 2 
-		memory = "6000GiB"
+		memory = "6GiB"
 
 		addons = [
 			"dashboard",
@@ -811,7 +812,7 @@ func testAcceptanceClusterConfig_OutOfOrderAddons(driver string, clusterName str
 		driver = "%s"
 		cluster_name = "%s"
 		cpus = 2 
-		memory = "6000GiB"
+		memory = "6GiB"
 
 		addons = [
 			"storage-provisioner",
@@ -829,7 +830,8 @@ func testAcceptanceClusterConfig_HAControlPlane(driver string, clusterName strin
 		driver = "%s"
 		cluster_name = "%s"
 		cpus = 2
-		memory = "6000GiB"
+		memory = "6GiB"
+		nodes = 3
 		ha = true
 	}
 	`, driver, clusterName)
@@ -841,7 +843,7 @@ func testAcceptanceClusterConfig_Wait(driver string, clusterName string) string 
 		driver = "%s"
 		cluster_name = "%s"
 		cpus = 2
-		memory = "6000GiB"
+		memory = "6GiB"
 
 		wait = [
 			"apps_running"
@@ -868,6 +870,26 @@ func verifyDelete(s *terraform.State) error {
 		_, err = os.Stat(profilesDir)
 		if err == nil {
 			return errors.New("profiles dir should not exist")
+		}
+
+		if rs.Primary.Attributes["driver"] == "docker" {
+			nodes, err := strconv.Atoi(rs.Primary.Attributes["nodes"])
+			if err != nil {
+				return err
+			}
+			for i := 1; i <= nodes; i++ {
+				name := clusterName
+				if i > 1 {
+					name = fmt.Sprintf("%s-m%02d", clusterName, i)
+				}
+				output, err := exec.Command("docker", "volume", "ls", "--filter", "label=name.minikube.sigs.k8s.io="+name, "--format", "{{.Name}}").CombinedOutput()
+				if err != nil {
+					return fmt.Errorf("check volumes for %s: %w: %s", name, err, output)
+				}
+				if strings.TrimSpace(string(output)) != "" {
+					return fmt.Errorf("node %s still has Docker volumes: %s", name, output)
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Two bugs that show up once the provider does more than one thing per process:

- **Addon assets were single-use.** Minikube keeps its bundled addon manifests as package-level `assets.Addon` readers. The CLI installs each one once and exits; a provider process installs them repeatedly, so every install after the first wrote an empty manifest. `resetAddonAssets` rewinds them before a cluster start or a `SetAddon`.
- **Addon failures were swallowed.** `MinikubeClient.Start` discarded the error from `setAddons`, so a broken addon left a cluster that looked healthy. It now wraps and returns it.
- **Multi-node deletes leaked volumes.** `Delete` used the config reconstructed from Terraform state, which only carries the primary node, so secondary nodes' Docker volumes survived a destroy. It now loads the saved profile (falling back to the passed config when no profile exists) so Minikube deletes every node.

## Test changes

- Cluster names in the acceptance tests are now DNS-safe lowercase (`test-cluster-creation-docker` rather than `TestClusterCreationDocker`).
- Dropped the `6000GiB` memory requests — no machine satisfies them — down to `6GiB`.
- The HA case now asks for `nodes = 3`, which is what makes the delete regression reproducible.
- `verifyDelete` asserts no Docker volumes remain for any node of a destroyed cluster.
- New unit tests: `TestResetAddonAssets` (contents restored across repeated installs) and `TestMinikubeClientStartReportsAddonFailure`.

## Test plan

Unit tests could not be run in the authoring environment — `libvirt-dev` / `libvirt-admin.pc` is missing, so `go build ./...` fails in `libvirt.org/go/libvirt` before reaching this code. `gofmt` is clean; CI covers the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)