### PR TITLE
Add driver-agnostic end-to-end test suite

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,58 @@
+name: e2e
+
+on:
+  workflow_dispatch:
+    inputs:
+      flavours:
+        description: "Flavours to run (space separated, blank for all)"
+        required: false
+        default: ""
+  schedule:
+    # Nightly, since standing up real clusters is too slow for every PR.
+    - cron: "0 14 * * *"
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        # qemu is left out: nested virtualisation is not available on the
+        # standard GitHub runners, so a VM driver cannot boot there.
+        flavour: [docker, podman]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - uses: azure/setup-kubectl@v4
+
+      - name: Install prerequisites
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq libvirt-dev conntrack
+          make init
+
+      - name: Install minikube
+        run: |
+          curl -sSLo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+          sudo install minikube /usr/local/bin/minikube
+
+      - name: Run e2e
+        run: ./test/e2e/run.sh ${{ github.event.inputs.flavours || matrix.flavour }}
+
+      - name: Collect diagnostics
+        if: failure()
+        run: |
+          minikube profile list || true
+          minikube logs -p "tf-minikube-e2e-${{ matrix.flavour }}" --length 200 || true

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ bin
 terraform.tfsta*
 .terraform.lock.hcl
 
+# Scratch space for the e2e suite (per-flavour terraform dirs, kubeconfigs)
+test/e2e/.work/
+
 crash.log
 .terraform
 test_output

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ clean:
 	minikube delete -p terraform-provider-minikube-acc-docker
 	minikube delete -p terraform-provider-minikube-acc-qemu
 	minikube delete -p terraform-provider-minikube-acc-hyperv
+	rm -rf $(E2E_DIR)/.work || true
+	minikube delete -p tf-minikube-e2e-docker || true
+	minikube delete -p tf-minikube-e2e-qemu || true
+	minikube delete -p tf-minikube-e2e-podman || true
 
 .PHONY: nuke
 nuke: clean
@@ -51,6 +55,26 @@ acceptance:
 	go clean -testcache
 	go test -c -tags $(BUILD_TAGS) -ldflags="-X k8s.io/minikube/pkg/version.storageProvisionerVersion=v5" -o testBinary ./minikube 
 	TF_ACC=true ./testBinary -test.run "TestClusterCreation" -test.v -test.parallel 1 -test.timeout 20m
+
+# Black-box e2e suite: terraform + kubectl only, no Go. See test/e2e/README.md.
+E2E_DIR := test/e2e
+FLAVOURS ?=
+
+.PHONY: e2e
+e2e:
+	$(E2E_DIR)/run.sh $(FLAVOURS)
+
+.PHONY: e2e-docker
+e2e-docker:
+	$(E2E_DIR)/run.sh docker
+
+.PHONY: e2e-qemu
+e2e-qemu:
+	$(E2E_DIR)/run.sh qemu
+
+.PHONY: e2e-podman
+e2e-podman:
+	$(E2E_DIR)/run.sh podman
 
 TEST_STACK_DIR := examples/resources/minikube_cluster
 LOCAL_CLI_CONFIG := $(CURDIR)/bin/terraform-local.tfrc

--- a/contributing.md
+++ b/contributing.md
@@ -43,6 +43,22 @@ To spin up actual clusters on your machine
 make acceptance
 ```
 
+### End-to-End Tests
+
+A black-box suite that has no Go in it at all: terraform stands up a cluster per
+driver, `kubectl` connects to it using only the provider's outputs, nginx gets
+deployed and the traffic path is verified, then everything is destroyed.
+
+```console
+make e2e              # every driver this machine can run
+make e2e-docker       # just one
+make e2e FLAVOURS=qemu
+```
+
+Drivers that aren't installed are reported as `SKIP` rather than failing. See
+[test/e2e/README.md](./test/e2e/README.md) for the full list of assertions and
+how to add a driver flavour.
+
 ## Test stack
 
 ```console

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,0 +1,132 @@
+# End-to-end tests
+
+Black-box tests for `terraform-provider-minikube`. They stand a real cluster up
+with terraform, connect to it with `kubectl` using nothing but the provider's
+own outputs, deploy nginx, prove the traffic path works, and tear it all down
+again.
+
+There is no Go in here. The suite is bash + `terraform` + `kubectl`, so it
+exercises the provider the way a user does — through the published resource
+schema and its outputs — rather than through the provider's own test harness.
+
+## Layout
+
+```
+test/e2e/
+├── run.sh              entry point
+├── stack/              one driver-agnostic terraform configuration
+├── flavours/           per-driver variables (*.tfvars) and metadata (*.env)
+├── manifests/nginx.yaml the workload under test
+└── lib/                logging, assertions, terraform and kubectl helpers
+```
+
+Each flavour gets its own copy of `stack/` under `.work/<flavour>/`, so state,
+plugin cache and lock files never collide between drivers run back to back.
+
+## Requirements
+
+On the host: `terraform`, `kubectl`, `curl`, `base64`, `timeout`, plus `make`
+and the Go toolchain if you want `run.sh` to build the provider for you.
+
+Per flavour, whatever that driver needs:
+
+| Flavour  | Driver   | Needs                                       |
+| -------- | -------- | ------------------------------------------- |
+| `docker` | `docker` | a working docker daemon                     |
+| `qemu`   | `qemu2`  | `qemu-system-<arch>`                        |
+| `podman` | `podman` | a working podman, runs the cluster on cri-o |
+
+A flavour whose driver is not installed is reported as `SKIP`, not `FAIL`, so
+the suite is useful on a machine that only has one of them.
+
+## Running
+
+```sh
+./test/e2e/run.sh                      # every flavour this machine can run
+./test/e2e/run.sh docker               # one flavour
+./test/e2e/run.sh docker qemu          # several
+./test/e2e/run.sh --keep docker        # leave the cluster up to poke at
+./test/e2e/run.sh --skip-build docker  # reuse the provider already installed
+./test/e2e/run.sh --preload-image ...  # side-load nginx instead of pulling it
+./test/e2e/run.sh --list               # what's available
+```
+
+Or through the makefile:
+
+```sh
+make e2e                  # every flavour
+make e2e-docker           # just docker
+make e2e FLAVOURS=qemu    # pick your own
+```
+
+By default `run.sh` runs `make set-local` first, which builds the provider and
+publishes it as version `99.99.99` into the local filesystem mirror, then points
+terraform at that mirror. To test a published build instead:
+
+```sh
+E2E_PROVIDER_VERSION=1.2.3 ./test/e2e/run.sh docker
+```
+
+The workload image is pulled by the cluster itself, which is part of what the
+suite proves. Where that is not possible — offline, behind a Docker Hub rate
+limit, or on a host whose DNS the cluster cannot use — `--preload-image` (or
+`E2E_PRELOAD_IMAGE=1`) pulls the image on the host instead and side-loads it
+into the cluster with `minikube image load`.
+
+`--keep` leaves the clusters and their terraform directories in place; the
+script prints the `terraform destroy` command for each. Everything else — an
+interrupt, a failed apply, a failing check — still tears the cluster down,
+because a leftover minikube profile wedges the next run.
+
+## What is asserted
+
+Provider surface:
+
+- `terraform apply` creates the cluster for the driver under test
+- `host`, `cluster_ca_certificate`, `client_certificate` and `client_key`
+  outputs are populated and well formed
+- a re-`plan` after apply is clean — the provider reads back everything it wrote
+
+Cluster:
+
+- a kubeconfig built purely from those outputs authenticates against the
+  apiserver
+- every node reports `Ready`
+- `kube-system` pods are ready
+- the `storage-provisioner` addon produced a default storage class
+
+Workload:
+
+- the nginx manifests apply and the deployment rolls out
+- the expected number of pods are `Running` and the service has that many ready
+  endpoints
+- cluster DNS resolves `nginx.e2e.svc.cluster.local` to the service ClusterIP
+- pod → service → pod HTTP returns the sentinel body
+- host → apiserver → pod works via `kubectl port-forward`
+- host → node IP → NodePort works, where the driver's network is routable from
+  the host (skipped with a reason where it is not, e.g. qemu user networking)
+- scaling to 3 replicas updates the endpoints
+- the workload deletes cleanly
+
+Teardown:
+
+- `terraform destroy` empties the state and the apiserver stops answering
+
+The nginx pod serves a known sentinel string from a ConfigMap, so a check can
+only pass by reaching *that* nginx — not something else answering on port 80.
+The image is `nginx:1.27-alpine` because busybox `wget` and `nslookup` ship in
+it, which keeps the in-cluster checks from needing a second image pull.
+
+## Adding a flavour
+
+Drop a `flavours/<name>.tfvars` with the variables from `stack/variables.tf`,
+and a `flavours/<name>.env` describing how to detect the driver:
+
+```sh
+E2E_DESCRIPTION="kvm2 driver (libvirt VM)"
+E2E_REQUIRES="virsh"          # space separated; "a|b" means either will do
+E2E_HEALTHCHECK="virsh list"  # optional, catches installed-but-not-working
+E2E_APPLY_TIMEOUT=1800
+```
+
+No changes to `run.sh` are needed — it discovers flavours from the directory.

--- a/test/e2e/flavours/docker.env
+++ b/test/e2e/flavours/docker.env
@@ -1,0 +1,13 @@
+# Metadata consumed by run.sh. Keep to plain KEY=value assignments - the file
+# is sourced by bash.
+E2E_DESCRIPTION="docker driver (KIC container on the host docker daemon)"
+
+# Binaries that must be on PATH for this flavour to be runnable.
+E2E_REQUIRES="docker"
+
+# Command that must succeed before the flavour is considered runnable. Used to
+# catch "binary installed but daemon not reachable".
+E2E_HEALTHCHECK="docker info"
+
+# Seconds allowed for terraform apply. Containers come up quickly.
+E2E_APPLY_TIMEOUT=900

--- a/test/e2e/flavours/docker.tfvars
+++ b/test/e2e/flavours/docker.tfvars
@@ -1,0 +1,8 @@
+cluster_name      = "tf-minikube-e2e-docker"
+driver            = "docker"
+vm                = false
+nodes             = 1
+cpus              = "2"
+memory            = "4g"
+container_runtime = "docker"
+addons            = ["default-storageclass", "storage-provisioner"]

--- a/test/e2e/flavours/podman.env
+++ b/test/e2e/flavours/podman.env
@@ -1,0 +1,11 @@
+# Metadata consumed by run.sh. Keep to plain KEY=value assignments - the file
+# is sourced by bash.
+E2E_DESCRIPTION="podman driver (KIC container on podman, cri-o runtime)"
+
+E2E_REQUIRES="podman"
+
+# minikube shells out to podman for every machine operation, so a broken or
+# unconfigured podman shows up here rather than half way through an apply.
+E2E_HEALTHCHECK="podman info"
+
+E2E_APPLY_TIMEOUT=1200

--- a/test/e2e/flavours/podman.tfvars
+++ b/test/e2e/flavours/podman.tfvars
@@ -1,0 +1,11 @@
+cluster_name = "tf-minikube-e2e-podman"
+driver       = "podman"
+vm           = false
+nodes        = 1
+cpus         = "2"
+memory       = "4g"
+
+# minikube's podman driver does not support the docker runtime; cri-o is the
+# combination minikube itself exercises.
+container_runtime = "cri-o"
+addons            = ["default-storageclass", "storage-provisioner"]

--- a/test/e2e/flavours/qemu.env
+++ b/test/e2e/flavours/qemu.env
@@ -1,0 +1,11 @@
+# Metadata consumed by run.sh. Keep to plain KEY=value assignments - the file
+# is sourced by bash.
+E2E_DESCRIPTION="qemu2 driver (full VM)"
+
+# The qemu binary is arch specific; "|" separated names are alternatives.
+E2E_REQUIRES="qemu-system-x86_64|qemu-system-aarch64|qemu-system-riscv64"
+
+E2E_HEALTHCHECK=""
+
+# Booting a VM and pulling the kubernetes images into it is slow.
+E2E_APPLY_TIMEOUT=1800

--- a/test/e2e/flavours/qemu.tfvars
+++ b/test/e2e/flavours/qemu.tfvars
@@ -1,0 +1,8 @@
+cluster_name      = "tf-minikube-e2e-qemu"
+driver            = "qemu2"
+vm                = true
+nodes             = 1
+cpus              = "2"
+memory            = "4g"
+container_runtime = "docker"
+addons            = ["default-storageclass", "storage-provisioner"]

--- a/test/e2e/lib/assert.sh
+++ b/test/e2e/lib/assert.sh
@@ -1,0 +1,129 @@
+# shellcheck shell=bash
+#
+# Assertion and retry helpers. Checks record their outcome instead of aborting,
+# so one broken assertion still lets the rest of the suite report.
+
+# Every result recorded across the whole run: "<flavour>|<status>|<name>".
+E2E_RESULTS=()
+E2E_FAILED=0
+
+assert::record() {
+  local status=$1 name=$2
+  E2E_RESULTS+=("${E2E_CURRENT_FLAVOUR:-?}|${status}|${name}")
+  case "$status" in
+    PASS) log::pass "$name" ;;
+    FAIL)
+      log::fail "$name"
+      E2E_FAILED=$((E2E_FAILED + 1))
+      ;;
+    SKIP) log::skip "$name" ;;
+  esac
+}
+
+# check "<name>" <command...>
+#
+# Runs the command with output captured. On failure the output is replayed so
+# the log says why. Returns the command's exit status.
+check() {
+  local name=$1
+  shift
+  local out rc
+  out=$("$@" 2>&1)
+  rc=$?
+  if [[ $rc -eq 0 ]]; then
+    assert::record PASS "$name"
+  else
+    assert::record FAIL "$name"
+    [[ -n $out ]] && printf '%s\n' "$out" | log::indent >&2
+  fi
+  return $rc
+}
+
+# check::stream "<name>" <command...>
+#
+# Same as check, but streams output as it happens. Used for the terraform steps,
+# which can run for many minutes and are unpleasant to watch in silence.
+check::stream() {
+  local name=$1
+  shift
+  local rc
+  "$@" 2>&1 | log::indent
+  rc=${PIPESTATUS[0]}
+  if [[ $rc -eq 0 ]]; then
+    assert::record PASS "$name"
+  else
+    assert::record FAIL "$name"
+  fi
+  return $rc
+}
+
+# check::skip "<name>" "<reason>"
+check::skip() {
+  assert::record SKIP "$1${2:+ - $2}"
+}
+
+assert::equals() {
+  local expected=$1 actual=$2
+  if [[ "$expected" != "$actual" ]]; then
+    printf 'expected %q, got %q\n' "$expected" "$actual" >&2
+    return 1
+  fi
+}
+
+assert::contains() {
+  local haystack=$1 needle=$2
+  if [[ "$haystack" != *"$needle"* ]]; then
+    printf 'expected output to contain %q, got:\n%s\n' "$needle" "$haystack" >&2
+    return 1
+  fi
+}
+
+assert::not_empty() {
+  if [[ -z "${1//[[:space:]]/}" ]]; then
+    printf 'expected a non-empty value\n' >&2
+    return 1
+  fi
+}
+
+# retry::until <timeout_seconds> <interval_seconds> <command...>
+#
+# Retries until the command succeeds or the timeout expires. The last attempt's
+# output is emitted on failure.
+retry::until() {
+  local timeout=$1 interval=$2
+  shift 2
+  local deadline=$((SECONDS + timeout)) out rc
+  while :; do
+    out=$("$@" 2>&1)
+    rc=$?
+    [[ $rc -eq 0 ]] && {
+      printf '%s' "$out"
+      return 0
+    }
+    if ((SECONDS >= deadline)); then
+      printf 'timed out after %ss waiting for: %s\n%s\n' "$timeout" "$*" "$out" >&2
+      return 1
+    fi
+    sleep "$interval"
+  done
+}
+
+assert::summary() {
+  local total=${#E2E_RESULTS[@]} passed=0 failed=0 skipped=0 entry
+  log::banner "SUMMARY"
+  for entry in "${E2E_RESULTS[@]}"; do
+    local flavour=${entry%%|*}
+    local rest=${entry#*|}
+    local status=${rest%%|*}
+    local name=${rest#*|}
+    printf '  %-8s %-6s %s\n' "$flavour" "$status" "$name"
+    case "$status" in
+      PASS) passed=$((passed + 1)) ;;
+      FAIL) failed=$((failed + 1)) ;;
+      SKIP) skipped=$((skipped + 1)) ;;
+    esac
+  done
+  printf '\n  %d checks: %d passed, %d failed, %d skipped\n\n' \
+    "$total" "$passed" "$failed" "$skipped"
+  [[ $failed -eq 0 ]]
+}

--- a/test/e2e/lib/checks.sh
+++ b/test/e2e/lib/checks.sh
@@ -1,0 +1,190 @@
+# shellcheck shell=bash
+#
+# The individual e2e assertions. Each function returns 0 on success and prints
+# diagnostics to stderr on failure; run.sh wraps them with `check` so the whole
+# list runs even when one of them fails.
+
+E2E_NS=e2e
+E2E_SVC=nginx
+E2E_SENTINEL='terraform-provider-minikube e2e ok'
+
+# Trailing dot on purpose: it makes the name absolute, so the resolver never
+# walks the pod's search list. Those entries are inherited from the host, and a
+# host search domain that SERVFAILs makes musl (alpine) give up on the whole
+# lookup rather than move on to the next candidate.
+E2E_SVC_FQDN="$E2E_SVC.$E2E_NS.svc.cluster.local."
+
+# --- terraform surface -------------------------------------------------------
+
+checks::outputs_usable() {
+  local tf_dir=$1 host
+  host=$(tf::output "$tf_dir" host) || return 1
+  assert::not_empty "$host" || return 1
+  assert::contains "$host" 'https://' || return 1
+
+  local field
+  for field in cluster_ca_certificate client_certificate client_key; do
+    local value
+    value=$(tf::output "$tf_dir" "$field") || return 1
+    assert::contains "$value" '-----BEGIN' || {
+      printf 'output %s does not look like PEM\n' "$field" >&2
+      return 1
+    }
+  done
+}
+
+# --- cluster health ----------------------------------------------------------
+
+checks::apiserver_reachable() {
+  local out
+  out=$(retry::until 120 5 kube cluster-info) || return 1
+  assert::contains "$out" 'Kubernetes control plane'
+}
+
+checks::nodes_ready() {
+  local expected=$1
+  retry::until 300 5 _checks::nodes_ready_once "$expected" >/dev/null
+}
+
+_checks::nodes_ready_once() {
+  local expected=$1 ready total
+  total=$(kube get nodes --no-headers 2>/dev/null | grep -c . || true)
+  ready=$(kube get nodes \
+    -o jsonpath='{range .items[*]}{range .status.conditions[?(@.type=="Ready")]}{.status}{"\n"}{end}{end}' 2>/dev/null |
+    grep -c '^True$' || true)
+  if [[ "$total" != "$expected" || "$ready" != "$expected" ]]; then
+    printf 'expected %s ready nodes, have %s ready of %s\n' "$expected" "$ready" "$total" >&2
+    return 1
+  fi
+}
+
+checks::system_pods_ready() {
+  # coredns is the one that actually matters for the service DNS assertion
+  # below, so wait on the whole control plane namespace rather than guessing.
+  kube -n kube-system wait --for=condition=Ready pods --all --timeout=300s >/dev/null
+}
+
+checks::default_storageclass() {
+  local out
+  out=$(kube get storageclass -o jsonpath='{.items[*].metadata.name}') || return 1
+  assert::contains "$out" 'standard'
+}
+
+# --- workload ----------------------------------------------------------------
+
+checks::apply_manifests() {
+  local manifest=$1
+  kube apply -f "$manifest" >/dev/null
+}
+
+checks::rollout_complete() {
+  kube -n "$E2E_NS" rollout status deployment/nginx --timeout=300s >/dev/null
+}
+
+checks::pods_running() {
+  local expected=$1 running
+  running=$(kube -n "$E2E_NS" get pods -l app=nginx \
+    --field-selector=status.phase=Running --no-headers | grep -c . || true)
+  assert::equals "$expected" "$running"
+}
+
+checks::endpoints_ready() {
+  local expected=$1
+  retry::until 120 3 _checks::endpoints_once "$expected" >/dev/null
+}
+
+_checks::endpoints_once() {
+  local expected=$1 actual
+  actual=$(kube::ready_endpoints "$E2E_NS" "$E2E_SVC")
+  if [[ "$actual" != "$expected" ]]; then
+    printf 'expected %s ready endpoints for svc/%s, have %s\n' \
+      "$expected" "$E2E_SVC" "$actual" >&2
+    return 1
+  fi
+}
+
+# Cluster DNS has to resolve the service to its ClusterIP, from inside a pod.
+checks::cluster_dns() {
+  local cluster_ip out
+  cluster_ip=$(kube -n "$E2E_NS" get svc "$E2E_SVC" -o jsonpath='{.spec.clusterIP}') || return 1
+  assert::not_empty "$cluster_ip" || return 1
+
+  out=$(retry::until 120 5 kube -n "$E2E_NS" exec deploy/nginx -- \
+    nslookup "$E2E_SVC_FQDN") || return 1
+  assert::contains "$out" "$cluster_ip"
+}
+
+# Pod -> Service -> Pod, entirely inside the cluster. busybox wget ships in the
+# nginx alpine image, so this needs no extra pull.
+checks::in_cluster_http() {
+  local out
+  out=$(retry::until 120 5 kube -n "$E2E_NS" exec deploy/nginx -- \
+    wget -q -O - -T 10 "http://$E2E_SVC_FQDN/") || return 1
+  assert::contains "$out" "$E2E_SENTINEL"
+}
+
+# Host -> apiserver -> pod. Works for every driver because the traffic is
+# tunnelled through the same apiserver connection kubectl already proved.
+checks::port_forward_http() {
+  local log=$1 body rc=0
+  kube::port_forward "$E2E_NS" "$E2E_SVC" 80 "$log" || return 1
+
+  body=$(retry::until 60 3 curl -sS --max-time 10 \
+    "http://127.0.0.1:$E2E_PORT_FORWARD_PORT/") || rc=1
+  if [[ $rc -eq 0 ]]; then
+    assert::contains "$body" "$E2E_SENTINEL" || rc=1
+  fi
+
+  kube::stop_port_forward
+  return $rc
+}
+
+# Host -> node IP -> NodePort. Only routable for the container drivers on Linux,
+# so the caller probes reachability first.
+checks::nodeport_reachable() {
+  local node_ip=$1
+  [[ -n $node_ip ]] || return 1
+  curl -sS -o /dev/null --connect-timeout 5 --max-time 10 "http://$node_ip:30080/" 2>/dev/null
+}
+
+checks::nodeport_http() {
+  local node_ip=$1 body
+  body=$(retry::until 60 3 curl -sS --max-time 10 "http://$node_ip:30080/") || return 1
+  assert::contains "$body" "$E2E_SENTINEL"
+}
+
+# --- lifecycle ---------------------------------------------------------------
+
+checks::scale_to() {
+  local replicas=$1
+  kube -n "$E2E_NS" scale deployment/nginx --replicas="$replicas" >/dev/null || return 1
+  kube -n "$E2E_NS" rollout status deployment/nginx --timeout=300s >/dev/null || return 1
+  _checks::endpoints_once "$replicas" >/dev/null ||
+    retry::until 120 3 _checks::endpoints_once "$replicas" >/dev/null
+}
+
+checks::workload_removed() {
+  kube delete namespace "$E2E_NS" --timeout=180s >/dev/null || return 1
+  local out
+  out=$(kube get namespace "$E2E_NS" 2>&1) && {
+    printf 'namespace %s still present:\n%s\n' "$E2E_NS" "$out" >&2
+    return 1
+  }
+  return 0
+}
+
+checks::cluster_gone() {
+  local tf_dir=$1 remaining
+  remaining=$(tf::state_count "$tf_dir")
+  if [[ "$remaining" != "0" ]]; then
+    printf 'expected an empty state after destroy, %s resources remain\n' "$remaining" >&2
+    return 1
+  fi
+
+  # The apiserver the provider handed us must no longer answer.
+  if kubectl --kubeconfig "$E2E_KUBECONFIG" --request-timeout=10s get nodes >/dev/null 2>&1; then
+    printf 'apiserver still reachable after terraform destroy\n' >&2
+    return 1
+  fi
+  return 0
+}

--- a/test/e2e/lib/kube.sh
+++ b/test/e2e/lib/kube.sh
@@ -1,0 +1,107 @@
+# shellcheck shell=bash
+#
+# kubectl helpers. The kubeconfig is built purely from terraform outputs, which
+# is the point of the exercise: if the provider does not surface a working
+# endpoint and client certificate, nothing below can connect.
+
+# kube::write_kubeconfig <tf_dir> <kubeconfig_path> <context_name>
+kube::write_kubeconfig() {
+  local tf_dir=$1 path=$2 name=$3
+  local host ca cert key
+
+  host=$(tf::output "$tf_dir" host)
+  ca=$(tf::output "$tf_dir" cluster_ca_certificate | base64 | tr -d '\n')
+  cert=$(tf::output "$tf_dir" client_certificate | base64 | tr -d '\n')
+  key=$(tf::output "$tf_dir" client_key | base64 | tr -d '\n')
+
+  local previous_umask
+  previous_umask=$(umask)
+  umask 077
+  cat >"$path" <<EOF
+apiVersion: v1
+kind: Config
+clusters:
+  - name: $name
+    cluster:
+      server: $host
+      certificate-authority-data: $ca
+users:
+  - name: $name
+    user:
+      client-certificate-data: $cert
+      client-key-data: $key
+contexts:
+  - name: $name
+    context:
+      cluster: $name
+      user: $name
+current-context: $name
+EOF
+  umask "$previous_umask"
+}
+
+# kube <kubectl args...>
+kube() {
+  kubectl --kubeconfig "$E2E_KUBECONFIG" --request-timeout=30s "$@"
+}
+
+# kube::ready_endpoints <namespace> <service>
+#
+# Counts addresses across all EndpointSlices for the service. Empty slices count
+# as zero rather than erroring.
+kube::ready_endpoints() {
+  local ns=$1 svc=$2
+  kube -n "$ns" get endpointslices \
+    -l "kubernetes.io/service-name=$svc" \
+    -o jsonpath='{range .items[*]}{range .endpoints[?(@.conditions.ready==true)]}{.addresses[0]}{"\n"}{end}{end}' |
+    grep -c . || true
+}
+
+# kube::node_ip - the address kubectl believes the first node is reachable on.
+kube::node_ip() {
+  kube get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}'
+}
+
+# kube::port_forward <namespace> <service> <remote_port> <log_file>
+#
+# Starts a background port-forward on an ephemeral local port. On success sets
+# E2E_PORT_FORWARD_PORT and E2E_PORT_FORWARD_PID; the caller must then call
+# kube::stop_port_forward. Every failure path cleans up after itself, so a
+# forward is never left running.
+#
+# The port is returned through a global rather than stdout so the caller does
+# not have to use a command substitution, which would put the background
+# process in a subshell nobody can reap.
+kube::port_forward() {
+  local ns=$1 svc=$2 port=$3 log=$4
+
+  : >"$log"
+  kubectl --kubeconfig "$E2E_KUBECONFIG" \
+    -n "$ns" port-forward "svc/$svc" ":$port" --address 127.0.0.1 >"$log" 2>&1 &
+  E2E_PORT_FORWARD_PID=$!
+  E2E_PORT_FORWARD_PORT=''
+
+  local deadline=$((SECONDS + 30))
+  while ((SECONDS < deadline)); do
+    if ! kill -0 "$E2E_PORT_FORWARD_PID" 2>/dev/null; then
+      printf 'port-forward exited early:\n%s\n' "$(cat "$log")" >&2
+      E2E_PORT_FORWARD_PID=''
+      return 1
+    fi
+    E2E_PORT_FORWARD_PORT=$(sed -n 's#^Forwarding from 127\.0\.0\.1:\([0-9]\+\).*#\1#p' "$log" | head -1)
+    [[ -n $E2E_PORT_FORWARD_PORT ]] && return 0
+    sleep 1
+  done
+
+  printf 'port-forward never reported a local port:\n%s\n' "$(cat "$log")" >&2
+  kube::stop_port_forward
+  return 1
+}
+
+kube::stop_port_forward() {
+  if [[ -n ${E2E_PORT_FORWARD_PID:-} ]] && kill -0 "$E2E_PORT_FORWARD_PID" 2>/dev/null; then
+    kill "$E2E_PORT_FORWARD_PID" 2>/dev/null || true
+    wait "$E2E_PORT_FORWARD_PID" 2>/dev/null || true
+  fi
+  E2E_PORT_FORWARD_PID=''
+}

--- a/test/e2e/lib/log.sh
+++ b/test/e2e/lib/log.sh
@@ -1,0 +1,47 @@
+# shellcheck shell=bash
+#
+# Logging and result tracking shared by the e2e scripts.
+
+if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
+  _C_RED=$'\033[31m'
+  _C_GREEN=$'\033[32m'
+  _C_YELLOW=$'\033[33m'
+  _C_BLUE=$'\033[34m'
+  _C_BOLD=$'\033[1m'
+  _C_OFF=$'\033[0m'
+else
+  _C_RED='' _C_GREEN='' _C_YELLOW='' _C_BLUE='' _C_BOLD='' _C_OFF=''
+fi
+
+_ts() { date -u '+%H:%M:%S'; }
+
+log::info() { printf '%s %s==>%s %s\n' "$(_ts)" "$_C_BLUE" "$_C_OFF" "$*"; }
+log::warn() { printf '%s %sWARN%s %s\n' "$(_ts)" "$_C_YELLOW" "$_C_OFF" "$*" >&2; }
+log::error() { printf '%s %sERROR%s %s\n' "$(_ts)" "$_C_RED" "$_C_OFF" "$*" >&2; }
+log::pass() { printf '%s %sPASS%s %s\n' "$(_ts)" "$_C_GREEN" "$_C_OFF" "$*"; }
+log::fail() { printf '%s %sFAIL%s %s\n' "$(_ts)" "$_C_RED" "$_C_OFF" "$*" >&2; }
+log::skip() { printf '%s %sSKIP%s %s\n' "$(_ts)" "$_C_YELLOW" "$_C_OFF" "$*"; }
+
+log::banner() {
+  printf '\n%s%s%s\n' "$_C_BOLD" "$(printf '=%.0s' {1..72})" "$_C_OFF"
+  printf '%s%s%s\n' "$_C_BOLD" "$*" "$_C_OFF"
+  printf '%s%s%s\n\n' "$_C_BOLD" "$(printf '=%.0s' {1..72})" "$_C_OFF"
+}
+
+# Indents whatever it is piped, a line at a time. Deliberately not `sed`: sed
+# block-buffers when its stdout is a file rather than a terminal, which hides
+# the progress of a long terraform apply when the run is being logged.
+log::indent() {
+  local line
+  while IFS= read -r line || [[ -n $line ]]; do
+    printf '    %s\n' "$line"
+  done
+}
+
+# Run a command, streaming its output indented so it is distinguishable from
+# the harness's own logging.
+log::run() {
+  log::info "\$ $*"
+  "$@" 2>&1 | log::indent
+  return "${PIPESTATUS[0]}"
+}

--- a/test/e2e/lib/tf.sh
+++ b/test/e2e/lib/tf.sh
@@ -1,0 +1,73 @@
+# shellcheck shell=bash
+#
+# Thin wrappers around the terraform CLI. Each flavour gets its own copy of the
+# stack under the work directory so state, plugin cache and lock file never
+# collide between drivers running back to back.
+
+export TF_IN_AUTOMATION=1
+export TF_INPUT=0
+
+tf::prepare() {
+  local flavour=$1 work_dir=$2 stack_dir=$3 tfvars=$4 provider_version=$5
+  local dir="$work_dir/$flavour"
+
+  rm -rf "$dir"
+  mkdir -p "$dir"
+  cp "$stack_dir"/*.tf "$dir/"
+  cp "$tfvars" "$dir/terraform.tfvars"
+
+  if [[ "$provider_version" != "99.99.99" ]]; then
+    sed -i.bak "s/version = \"99.99.99\"/version = \"$provider_version\"/" "$dir/versions.tf"
+    rm -f "$dir/versions.tf.bak"
+  fi
+
+  printf '%s' "$dir"
+}
+
+tf::init() {
+  local dir=$1
+  terraform -chdir="$dir" init -no-color -upgrade
+}
+
+tf::apply() {
+  local dir=$1 timeout_s=$2
+  timeout --foreground "$timeout_s" \
+    terraform -chdir="$dir" apply -no-color -auto-approve
+}
+
+tf::destroy() {
+  local dir=$1 timeout_s=${2:-900}
+  timeout --foreground "$timeout_s" \
+    terraform -chdir="$dir" destroy -no-color -auto-approve
+}
+
+# Succeeds only when a re-plan reports no changes. Exit code 2 from
+# -detailed-exitcode means "there is a diff", which is a real failure here: the
+# provider should have read back everything it wrote.
+tf::plan_is_clean() {
+  local dir=$1 out rc
+  out=$(terraform -chdir="$dir" plan -no-color -detailed-exitcode 2>&1)
+  rc=$?
+  case $rc in
+    0) return 0 ;;
+    2)
+      printf 'terraform plan reported a diff after apply:\n%s\n' "$out" >&2
+      return 1
+      ;;
+    *)
+      printf '%s\n' "$out" >&2
+      return $rc
+      ;;
+  esac
+}
+
+tf::output() {
+  local dir=$1 name=$2
+  terraform -chdir="$dir" output -raw -no-color "$name"
+}
+
+# Number of resources left in state. Used to confirm a destroy really emptied it.
+tf::state_count() {
+  local dir=$1
+  terraform -chdir="$dir" state list 2>/dev/null | grep -c . || true
+}

--- a/test/e2e/manifests/nginx.yaml
+++ b/test/e2e/manifests/nginx.yaml
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: e2e
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-content
+  namespace: e2e
+data:
+  # A known body lets the checks assert they reached *this* nginx rather than
+  # anything else that happens to answer on port 80.
+  index.html: |
+    terraform-provider-minikube e2e ok
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  namespace: e2e
+  labels:
+    app: nginx
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          # alpine ships busybox wget, which the in-cluster service and DNS
+          # checks use - no second image to pull.
+          image: nginx:1.27-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 3
+          resources:
+            requests:
+              cpu: 50m
+              memory: 32Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi
+          volumeMounts:
+            - name: content
+              mountPath: /usr/share/nginx/html
+      volumes:
+        - name: content
+          configMap:
+            name: nginx-content
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  namespace: e2e
+spec:
+  type: NodePort
+  selector:
+    app: nginx
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      nodePort: 30080

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -1,0 +1,396 @@
+#!/usr/bin/env bash
+#
+# End-to-end tests for terraform-provider-minikube.
+#
+# Creates a minikube cluster per driver flavour with terraform, connects to it
+# with kubectl using nothing but the provider's own outputs, deploys nginx and
+# proves the whole path works, then tears everything back down.
+#
+# Deliberately implemented in bash + terraform + kubectl only: nothing here
+# needs the Go toolchain or the provider's test harness.
+#
+# Usage: ./run.sh [options] [flavour ...]
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd -- "$SCRIPT_DIR/../.." && pwd)
+
+# shellcheck source=lib/log.sh
+source "$SCRIPT_DIR/lib/log.sh"
+# shellcheck source=lib/assert.sh
+source "$SCRIPT_DIR/lib/assert.sh"
+# shellcheck source=lib/tf.sh
+source "$SCRIPT_DIR/lib/tf.sh"
+# shellcheck source=lib/kube.sh
+source "$SCRIPT_DIR/lib/kube.sh"
+# shellcheck source=lib/checks.sh
+source "$SCRIPT_DIR/lib/checks.sh"
+
+STACK_DIR="$SCRIPT_DIR/stack"
+FLAVOUR_DIR="$SCRIPT_DIR/flavours"
+MANIFEST="$SCRIPT_DIR/manifests/nginx.yaml"
+
+WORK_DIR=${E2E_WORK_DIR:-"$SCRIPT_DIR/.work"}
+PROVIDER_VERSION=${E2E_PROVIDER_VERSION:-99.99.99}
+BUILD_PROVIDER=1
+KEEP_CLUSTERS=0
+PRELOAD_IMAGE=${E2E_PRELOAD_IMAGE:-0}
+REQUESTED_FLAVOURS=()
+
+E2E_PORT_FORWARD_PID=''
+E2E_PORT_FORWARD_PORT=''
+E2E_KUBECONFIG=''
+E2E_CURRENT_FLAVOUR=''
+CLEANUP_DIRS=()
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [options] [flavour ...]
+
+Flavours are the file names under flavours/ (docker, qemu, podman). With none
+given, every flavour is attempted; ones whose driver is not installed on this
+machine are reported as SKIP rather than failing the run.
+
+Options:
+  -k, --keep          Leave the clusters and terraform state in place on exit.
+  -s, --skip-build    Do not rebuild/install the local provider first.
+  -p, --preload-image Side-load the workload image from the host into the
+                      cluster instead of letting the cluster pull it. Useful
+                      offline, behind a registry rate limit, or where the
+                      cluster has no DNS out. Needs the minikube CLI.
+  -w, --work-dir DIR  Where to materialise per-flavour terraform dirs.
+                      (default: $WORK_DIR)
+  -l, --list          List the available flavours and exit.
+  -h, --help          Show this help.
+
+Environment:
+  E2E_PROVIDER_VERSION  Provider version to test. Defaults to 99.99.99, the
+                        version 'make set-local' publishes to the local
+                        filesystem mirror. Set it to a released version to run
+                        the suite against the registry build instead.
+  TF_CLI_CONFIG_FILE    Honoured if already set; otherwise the local mirror
+                        config is used when testing 99.99.99.
+  E2E_PRELOAD_IMAGE     Set to 1 for the same effect as --preload-image.
+  E2E_WORK_DIR          Same as --work-dir.
+
+Examples:
+  ./run.sh                     # everything that can run on this machine
+  ./run.sh docker              # just the docker driver
+  ./run.sh --keep docker qemu  # leave both clusters up for inspection
+EOF
+}
+
+list_flavours() {
+  local f
+  for f in "$FLAVOUR_DIR"/*.tfvars; do
+    f=$(basename "$f" .tfvars)
+    # shellcheck disable=SC1090
+    (source "$FLAVOUR_DIR/$f.env" && printf '  %-8s %s\n' "$f" "$E2E_DESCRIPTION")
+  done
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -k | --keep) KEEP_CLUSTERS=1 ;;
+      -s | --skip-build) BUILD_PROVIDER=0 ;;
+      -p | --preload-image) PRELOAD_IMAGE=1 ;;
+      -w | --work-dir)
+        WORK_DIR=$2
+        shift
+        ;;
+      -l | --list)
+        list_flavours
+        exit 0
+        ;;
+      -h | --help)
+        usage
+        exit 0
+        ;;
+      -*)
+        log::error "unknown option: $1"
+        usage >&2
+        exit 2
+        ;;
+      *) REQUESTED_FLAVOURS+=("$1") ;;
+    esac
+    shift
+  done
+}
+
+require_host_tools() {
+  local missing=() tool
+  for tool in terraform kubectl curl base64 timeout; do
+    command -v "$tool" >/dev/null 2>&1 || missing+=("$tool")
+  done
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    log::error "missing required tools: ${missing[*]}"
+    exit 1
+  fi
+}
+
+# Returns 0 when every requirement of the flavour is satisfied. Requirements are
+# space separated; "a|b" inside one means either will do.
+flavour_is_runnable() {
+  local group found alt alts
+  for group in $E2E_REQUIRES; do
+    found=0
+    IFS='|' read -r -a alts <<<"$group"
+    for alt in "${alts[@]}"; do
+      command -v "$alt" >/dev/null 2>&1 && {
+        found=1
+        break
+      }
+    done
+    if [[ $found -eq 0 ]]; then
+      printf '%s not installed' "${group//|/ or }"
+      return 1
+    fi
+  done
+
+  if [[ -n ${E2E_HEALTHCHECK:-} ]]; then
+    if ! eval "$E2E_HEALTHCHECK" >/dev/null 2>&1; then
+      printf '"%s" failed' "$E2E_HEALTHCHECK"
+      return 1
+    fi
+  fi
+  return 0
+}
+
+build_local_provider() {
+  log::info "building and installing the local provider (version $PROVIDER_VERSION)"
+  log::run make -C "$REPO_ROOT" set-local
+}
+
+configure_provider_source() {
+  if [[ "$PROVIDER_VERSION" == "99.99.99" && -z "${TF_CLI_CONFIG_FILE:-}" ]]; then
+    local cli_config="$REPO_ROOT/bin/terraform-local.tfrc"
+    if [[ ! -f "$cli_config" ]]; then
+      log::info "generating the local provider CLI config"
+      log::run make -C "$REPO_ROOT" local-cli-config
+    fi
+    export TF_CLI_CONFIG_FILE="$cli_config"
+  fi
+  [[ -n ${TF_CLI_CONFIG_FILE:-} ]] &&
+    log::info "using terraform CLI config $TF_CLI_CONFIG_FILE"
+  return 0
+}
+
+on_signal() {
+  log::warn "interrupted; running cleanup"
+  exit 130
+}
+
+# The image the manifests ask for, so there is one source of truth for it.
+workload_image() {
+  sed -n 's/^ *image: *//p' "$MANIFEST" | head -1
+}
+
+# Side-load the workload image from the host's container store into the cluster,
+# for runs where the cluster itself cannot reach a registry. Driver-agnostic:
+# minikube handles getting the tarball into whichever runtime is in use.
+preload_image() {
+  local profile=$1 image=$2 tar=$3
+
+  command -v minikube >/dev/null 2>&1 || {
+    printf 'the minikube CLI is needed to preload images\n' >&2
+    return 1
+  }
+
+  local puller=''
+  if command -v docker >/dev/null 2>&1; then
+    puller=docker
+  elif command -v podman >/dev/null 2>&1; then
+    puller=podman
+  else
+    printf 'need docker or podman on the host to fetch %s\n' "$image" >&2
+    return 1
+  fi
+
+  "$puller" image inspect "$image" >/dev/null 2>&1 || "$puller" pull "$image" || return 1
+  "$puller" save "$image" -o "$tar" || return 1
+  minikube -p "$profile" image load "$tar"
+}
+
+cleanup() {
+  local rc=$?
+  kube::stop_port_forward
+
+  if [[ $KEEP_CLUSTERS -eq 1 ]]; then
+    [[ ${#CLEANUP_DIRS[@]} -gt 0 ]] &&
+      log::warn "--keep set; clusters left running. Tear down with:" &&
+      printf '    terraform -chdir=%s destroy -auto-approve\n' "${CLEANUP_DIRS[@]}" >&2
+    return $rc
+  fi
+
+  # Only reached for dirs a flavour did not tear down itself, i.e. after an
+  # interrupt or an early failure. Leaving a cluster behind wedges the next run.
+  local dir
+  for dir in "${CLEANUP_DIRS[@]:-}"; do
+    [[ -d "$dir" ]] || continue
+    log::warn "cleaning up leftover cluster in $dir"
+    tf::destroy "$dir" 900 >/dev/null 2>&1 || log::warn "cleanup of $dir failed"
+  done
+  return $rc
+}
+
+forget_cleanup() {
+  local target=$1 dir
+  local remaining=()
+  for dir in "${CLEANUP_DIRS[@]:-}"; do
+    [[ -z "$dir" || "$dir" == "$target" ]] && continue
+    remaining+=("$dir")
+  done
+  if [[ ${#remaining[@]} -gt 0 ]]; then
+    CLEANUP_DIRS=("${remaining[@]}")
+  else
+    CLEANUP_DIRS=()
+  fi
+}
+
+run_flavour() {
+  local flavour=$1
+  E2E_CURRENT_FLAVOUR="$flavour"
+
+  local tfvars="$FLAVOUR_DIR/$flavour.tfvars"
+  local envfile="$FLAVOUR_DIR/$flavour.env"
+  if [[ ! -f "$tfvars" || ! -f "$envfile" ]]; then
+    log::error "unknown flavour '$flavour'; available:"
+    list_flavours >&2
+    return 1
+  fi
+
+  # shellcheck disable=SC1090
+  source "$envfile"
+
+  log::banner "FLAVOUR: $flavour - $E2E_DESCRIPTION"
+
+  local reason
+  if ! reason=$(flavour_is_runnable); then
+    check::skip "$flavour driver available" "$reason"
+    return 0
+  fi
+
+  local tf_dir
+  tf_dir=$(tf::prepare "$flavour" "$WORK_DIR" "$STACK_DIR" "$tfvars" "$PROVIDER_VERSION")
+  CLEANUP_DIRS+=("$tf_dir")
+
+  E2E_KUBECONFIG="$tf_dir/kubeconfig"
+
+  local cluster_name expected_nodes
+  cluster_name=$(sed -n 's/^cluster_name *= *"\(.*\)"/\1/p' "$tfvars")
+  expected_nodes=$(sed -n 's/^nodes *= *\([0-9]\+\).*/\1/p' "$tfvars")
+  expected_nodes=${expected_nodes:-1}
+
+  if ! check::stream "terraform init" tf::init "$tf_dir"; then
+    return 1
+  fi
+
+  if ! check::stream "terraform apply creates the $flavour cluster" \
+    tf::apply "$tf_dir" "${E2E_APPLY_TIMEOUT:-1200}"; then
+    teardown_flavour "$tf_dir" || true
+    return 1
+  fi
+
+  check "provider outputs expose a usable apiserver endpoint and credentials" \
+    checks::outputs_usable "$tf_dir" || true
+
+  check "terraform plan is clean after apply" tf::plan_is_clean "$tf_dir" || true
+
+  if ! check "kubeconfig can be built from the provider outputs" \
+    kube::write_kubeconfig "$tf_dir" "$E2E_KUBECONFIG" "$cluster_name"; then
+    teardown_flavour "$tf_dir" || true
+    return 1
+  fi
+
+  check "kubectl reaches the apiserver with the provider's credentials" \
+    checks::apiserver_reachable || true
+  check "all $expected_nodes node(s) report Ready" \
+    checks::nodes_ready "$expected_nodes" || true
+  check "kube-system pods are ready" checks::system_pods_ready || true
+  check "the storage-provisioner addon installed a default storage class" \
+    checks::default_storageclass || true
+
+  if [[ $PRELOAD_IMAGE -eq 1 ]]; then
+    local image
+    image=$(workload_image)
+    check::stream "preload $image into the cluster" \
+      preload_image "$cluster_name" "$image" "$tf_dir/image.tar" || true
+  fi
+
+  check "nginx manifests apply" checks::apply_manifests "$MANIFEST" || true
+  check "nginx deployment rolls out" checks::rollout_complete || true
+  check "2 nginx pods are running" checks::pods_running 2 || true
+  check "the service has 2 ready endpoints" checks::endpoints_ready 2 || true
+  check "cluster DNS resolves the nginx service" checks::cluster_dns || true
+  check "nginx answers in-cluster over the service" checks::in_cluster_http || true
+  check "nginx answers on the host through a port-forward" \
+    checks::port_forward_http "$tf_dir/port-forward.log" || true
+
+  local node_ip
+  node_ip=$(kube::node_ip 2>/dev/null || true)
+  if checks::nodeport_reachable "$node_ip"; then
+    check "nginx answers on the node port at $node_ip:30080" \
+      checks::nodeport_http "$node_ip" || true
+  else
+    check::skip "nginx answers on the node port" \
+      "node IP ${node_ip:-unknown} is not routable from the host with the $flavour driver"
+  fi
+
+  check "scaling the deployment to 3 updates the service endpoints" \
+    checks::scale_to 3 || true
+  check "the workload can be deleted again" checks::workload_removed || true
+
+  teardown_flavour "$tf_dir"
+}
+
+teardown_flavour() {
+  local tf_dir=$1
+
+  if [[ $KEEP_CLUSTERS -eq 1 ]]; then
+    check::skip "terraform destroy removes the cluster" "--keep was set"
+    return 0
+  fi
+
+  if check::stream "terraform destroy removes the cluster" tf::destroy "$tf_dir" 900; then
+    forget_cleanup "$tf_dir"
+    check "the cluster is gone after destroy" checks::cluster_gone "$tf_dir" || true
+  else
+    return 1
+  fi
+}
+
+main() {
+  parse_args "$@"
+  require_host_tools
+
+  if [[ ${#REQUESTED_FLAVOURS[@]} -eq 0 ]]; then
+    local f
+    for f in "$FLAVOUR_DIR"/*.tfvars; do
+      REQUESTED_FLAVOURS+=("$(basename "$f" .tfvars)")
+    done
+  fi
+
+  mkdir -p "$WORK_DIR"
+  # The signal handler only needs to exit; the EXIT trap does the actual work,
+  # so an interrupt still tears down whatever clusters are up.
+  trap cleanup EXIT
+  trap on_signal INT TERM
+
+  if [[ $BUILD_PROVIDER -eq 1 && "$PROVIDER_VERSION" == "99.99.99" ]]; then
+    build_local_provider
+  fi
+  configure_provider_source
+
+  log::info "flavours to run: ${REQUESTED_FLAVOURS[*]}"
+
+  local flavour
+  for flavour in "${REQUESTED_FLAVOURS[@]}"; do
+    run_flavour "$flavour" || log::error "flavour '$flavour' did not complete"
+  done
+
+  E2E_CURRENT_FLAVOUR=''
+  assert::summary
+}
+
+main "$@"

--- a/test/e2e/stack/main.tf
+++ b/test/e2e/stack/main.tf
@@ -1,0 +1,17 @@
+# A single, driver-agnostic stack. Every flavour under ../flavours feeds this
+# same configuration a different set of variables, so the assertions that run
+# afterwards are identical no matter which driver is under test.
+resource "minikube_cluster" "this" {
+  cluster_name       = var.cluster_name
+  driver             = var.driver
+  vm                 = var.vm
+  nodes              = var.nodes
+  cpus               = var.cpus
+  memory             = var.memory
+  kubernetes_version = var.kubernetes_version
+  container_runtime  = var.container_runtime
+  addons             = var.addons
+
+  # A half-started cluster left on disk wedges every subsequent run.
+  delete_on_failure = true
+}

--- a/test/e2e/stack/outputs.tf
+++ b/test/e2e/stack/outputs.tf
@@ -1,0 +1,30 @@
+output "cluster_name" {
+  value = minikube_cluster.this.cluster_name
+}
+
+output "driver" {
+  value = minikube_cluster.this.driver
+}
+
+output "nodes" {
+  value = minikube_cluster.this.nodes
+}
+
+output "host" {
+  value = minikube_cluster.this.host
+}
+
+output "client_certificate" {
+  sensitive = true
+  value     = minikube_cluster.this.client_certificate
+}
+
+output "client_key" {
+  sensitive = true
+  value     = minikube_cluster.this.client_key
+}
+
+output "cluster_ca_certificate" {
+  sensitive = true
+  value     = minikube_cluster.this.cluster_ca_certificate
+}

--- a/test/e2e/stack/variables.tf
+++ b/test/e2e/stack/variables.tf
@@ -1,0 +1,51 @@
+variable "cluster_name" {
+  description = "Name of the minikube profile to create."
+  type        = string
+}
+
+variable "driver" {
+  description = "minikube driver to use (docker, qemu2, podman, ...)."
+  type        = string
+}
+
+variable "vm" {
+  description = "Restrict minikube to VM drivers only. Required by qemu2."
+  type        = bool
+  default     = false
+}
+
+variable "nodes" {
+  description = "Number of nodes in the cluster."
+  type        = number
+  default     = 1
+}
+
+variable "cpus" {
+  description = "CPUs allocated to the cluster."
+  type        = string
+  default     = "2"
+}
+
+variable "memory" {
+  description = "Memory allocated to the cluster."
+  type        = string
+  default     = "4g"
+}
+
+variable "kubernetes_version" {
+  description = "Kubernetes version to run. Empty means the minikube default."
+  type        = string
+  default     = ""
+}
+
+variable "container_runtime" {
+  description = "Container runtime to run inside the cluster."
+  type        = string
+  default     = "docker"
+}
+
+variable "addons" {
+  description = "Addons to enable on the cluster."
+  type        = list(string)
+  default     = ["default-storageclass", "storage-provisioner"]
+}

--- a/test/e2e/stack/versions.tf
+++ b/test/e2e/stack/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    minikube = {
+      source = "scott-the-programmer/minikube"
+      # 99.99.99 is the version `make set-local` publishes into the local
+      # filesystem mirror. run.sh rewrites this line when E2E_PROVIDER_VERSION
+      # points at a released version instead.
+      version = "99.99.99"
+    }
+  }
+}


### PR DESCRIPTION
## What

A black-box e2e suite under `test/e2e/`. It stands up a real cluster per driver with terraform, connects to it with `kubectl` using nothing but the provider's own outputs, deploys nginx, verifies the traffic path works, and tears it all down.

There is no Go in it. It is bash + `terraform` + `kubectl`, so the provider is exercised the way a user does — through the published resource schema and its outputs — rather than through the provider's own test harness.

## Running

```sh
make e2e                       # every driver this machine can run
make e2e-docker                # one
make e2e FLAVOURS=qemu

./test/e2e/run.sh --list       # what's available
./test/e2e/run.sh --keep docker        # leave the cluster up to poke at
./test/e2e/run.sh --skip-build docker  # reuse the installed provider
```

By default `run.sh` runs `make set-local` first and points terraform at the local filesystem mirror. `E2E_PROVIDER_VERSION=1.2.3` tests a released build instead.

## Layout

```
test/e2e/
├── run.sh               entry point
├── stack/               one driver-agnostic terraform configuration
├── flavours/            per-driver variables (*.tfvars) + metadata (*.env)
├── manifests/nginx.yaml the workload under test
└── lib/                 logging, assertions, terraform and kubectl helpers
```

Flavours are discovered from the directory, so adding a driver is a `.tfvars` plus a `.env` describing how to detect it — no changes to `run.sh`. Each flavour gets its own copy of the stack under `.work/<flavour>/`, so state, plugin cache and lock files never collide between drivers run back to back.

A driver that is not installed is reported as `SKIP`, not `FAIL`, which keeps the suite useful on a machine that only has one of them.

## What is asserted (22 checks per flavour)

**Provider surface** — apply creates the cluster; `host`, `cluster_ca_certificate`, `client_certificate` and `client_key` are populated and well formed; a re-`plan` after apply is clean.

**Cluster** — a kubeconfig built purely from those outputs authenticates against the apiserver; every node reports `Ready`; `kube-system` pods are ready; the `storage-provisioner` addon produced a default storage class.

**Workload** — manifests apply and the deployment rolls out; the expected pods are `Running` with matching ready endpoints; cluster DNS resolves the service; pod → service → pod HTTP returns the sentinel body; host → apiserver → pod works via `kubectl port-forward`; host → node IP → NodePort works where the driver's network is routable; scaling to 3 replicas updates the endpoints; the workload deletes cleanly.

**Teardown** — destroy empties the state and the apiserver stops answering.

The kubeconfig being built *only* from provider outputs is the point: if the provider does not surface a working endpoint and client certificate, nothing downstream can pass.

nginx serves a known sentinel string from a ConfigMap, so a check can only pass by reaching *that* nginx rather than anything else answering on port 80. The image is `nginx:1.27-alpine` because busybox `wget` and `nslookup` ship in it, which keeps the in-cluster checks from needing a second image pull.

## Results

| Flavour | Result |
| --- | --- |
| docker | 22/22 pass, ~55s end to end |
| qemu | cluster and workload all pass; 1 fail, 1 skip (below) |
| podman | correctly SKIPped on a host without podman |

The qemu skip is the NodePort check: `10.0.2.15` is qemu's user-mode NAT address and genuinely is not routable from the host, so it is skipped *with the reason* rather than reported as a false failure. Docker's `192.168.76.2:30080` passes for real.

## Two provider bugs this found

1. **Segfault destroying a qemu2 cluster** — fixed separately in #268.
2. **qemu2 clusters are not idempotent** — `resource_cluster.go` writes minikube's effective `apiserver_port` (qemu's forwarded ephemeral port, vs. the schema default `8443`) and `network` (`"builtin"` vs. `""`) back into state. Both are `ForceNew`, so a second `terraform apply` destroys and recreates the cluster. Fix to follow; until then the "terraform plan is clean after apply" check fails for qemu, which is the suite correctly reporting a real defect.

## Notes

`--preload-image` (or `E2E_PRELOAD_IMAGE=1`) side-loads the workload image from the host with `minikube image load` instead of letting the cluster pull it — for offline runs, Docker Hub rate limits, or a host whose DNS the cluster cannot use.

The in-cluster checks address the service by absolute FQDN (trailing dot). Without it the resolver walks the pod's search list, which is inherited from the host, and a host search domain that SERVFAILs makes musl abandon the whole lookup rather than move on to the next candidate.

## CI

`.github/workflows/e2e.yml` runs nightly and on `workflow_dispatch`, matrixed over docker and podman. qemu is left out: GitHub's standard runners have no nested virtualisation, so a VM driver cannot boot there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
