### PR TITLE
Stop qemu2 clusters replacing themselves on every apply

### DIFF
--- a/minikube/generator/schema_builder.go
+++ b/minikube/generator/schema_builder.go
@@ -31,11 +31,21 @@ func (m *MinikubeHostBinary) GetStartHelpText(ctx context.Context) (string, erro
 	return run(ctx, "start", "--help")
 }
 
+// Fields whose effective value is chosen by minikube rather than by the
+// practitioner. They are Optional so a value can still be requested, and
+// Computed so that leaving them out accepts whatever the cluster reports
+// instead of producing a permanent diff against a schema default.
 var computedFields []string = []string{
 	"apiserver_names",
+	// minikube allocates a random free host port for the QEMU builtin
+	// network, and picks a different one on every start.
+	"apiserver_port",
 	"hyperkit_vsock_ports",
 	"insecure_registry",
 	"iso_url",
+	// minikube resolves an unset network per driver, e.g. "builtin" or
+	// "socket_vmnet" for QEMU.
+	"network",
 	"nfs_share",
 	"ports",
 	"registry_mirror",
@@ -383,7 +393,8 @@ var (
 	body := ""
 	for _, entry := range entries {
 		extraParams := ""
-		if contains(computedFields, entry.Parameter) {
+		computed := contains(computedFields, entry.Parameter)
+		if computed {
 			extraParams = `
 			Computed:			true,
 `
@@ -409,7 +420,9 @@ var (
 		} else if entry.DefaultFunc != "" {
 			extraParams += fmt.Sprintf(`
 			DefaultFunc:	%s,`, entry.DefaultFunc)
-		} else {
+		} else if !computed {
+			// The SDK rejects a schema that carries both Default and Computed;
+			// for a computed field the cluster's own value is the default.
 			extraParams += fmt.Sprintf(`
 			Default:	%s,`, entry.Default)
 		}

--- a/minikube/generator/schema_builder_test.go
+++ b/minikube/generator/schema_builder_test.go
@@ -315,6 +315,9 @@ func GetClusterSchema() map[string]*schema.Schema {
 	`, schema)
 }
 
+// A computed field must not carry a Default. The SDK rejects a schema with
+// both, and the point of marking a field computed is that minikube's own value
+// is authoritative when the practitioner does not request one.
 func TestComputedProperty(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockMinikube := NewMockMinikubeBinary(ctrl)
@@ -337,7 +340,6 @@ func TestComputedProperty(t *testing.T) {
 			Optional:			true,
 			ForceNew:			true,
 
-			Default:	123,
 		},
 
 	}

--- a/minikube/resource_cluster.go
+++ b/minikube/resource_cluster.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/constants"
 	minikubeDriver "k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/kubeconfig"
 	pkgutil "k8s.io/minikube/pkg/util"
@@ -30,6 +31,18 @@ func resolveNetwork(driver, network string) string {
 	}
 
 	return network
+}
+
+// resolveAPIServerPort supplies minikube's own default when the practitioner
+// has not asked for a specific port. apiserver_port is Optional+Computed rather
+// than defaulted in the schema, because minikube picks a random free host port
+// for the QEMU builtin network, so an unset attribute reads back as zero here.
+func resolveAPIServerPort(port int) int {
+	if port == 0 {
+		return constants.APIServerPort
+	}
+
+	return port
 }
 
 func ResourceCluster() *schema.Resource {
@@ -308,7 +321,7 @@ func initialiseMinikubeClient(d *schema.ResourceData, m interface{}) (lib.Cluste
 		}
 	}
 
-	apiserverPort := d.Get("apiserver_port").(int)
+	apiserverPort := resolveAPIServerPort(d.Get("apiserver_port").(int))
 
 	ecSlice := []string{}
 	if d.Get("extra_config") != nil && d.Get("extra_config").(*schema.Set).Len() > 0 {

--- a/minikube/resource_cluster_test.go
+++ b/minikube/resource_cluster_test.go
@@ -63,6 +63,28 @@ func TestResolveNetwork(t *testing.T) {
 	}
 }
 
+func TestResolveAPIServerPort(t *testing.T) {
+	tests := []struct {
+		name string
+		port int
+		want int
+	}{
+		// apiserver_port is Optional+Computed, so an unset attribute arrives
+		// here as zero rather than as the old schema default.
+		{name: "unset falls back to the minikube default", port: 0, want: 8443},
+		{name: "explicit port is honoured", port: 9443, want: 9443},
+		{name: "driver assigned port is honoured", port: 33665, want: 33665},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveAPIServerPort(tt.port); got != tt.want {
+				t.Fatalf("resolveAPIServerPort(%d) = %d, want %d", tt.port, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestClusterCreation(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		IsUnitTest: true,
@@ -507,13 +529,15 @@ func getBaseMockClient(t *testing.T, ctrl *gomock.Controller, clusterName string
 	}
 
 	cc := config.ClusterConfig{
-		Name:                    "terraform-provider-minikube-acc",
-		APIServerPort:           clusterSchema["apiserver_port"].Default.(int),
+		Name: "terraform-provider-minikube-acc",
+		// apiserver_port and network are Optional+Computed, so they carry no
+		// schema default; the provider resolves them from an unset value.
+		APIServerPort:           resolveAPIServerPort(0),
 		KeepContext:             clusterSchema["keep_context"].Default.(bool),
 		EmbedCerts:              clusterSchema["embed_certs"].Default.(bool),
 		MinikubeISO:             defaultIso,
 		KicBaseImage:            clusterSchema["base_image"].Default.(string),
-		Network:                 clusterSchema["network"].Default.(string),
+		Network:                 resolveNetwork("some_driver", ""),
 		Memory:                  mem,
 		CPUs:                    c,
 		DiskSize:                diskSize,

--- a/minikube/schema_cluster.go
+++ b/minikube/schema_cluster.go
@@ -100,10 +100,10 @@ var (
 			Type:        schema.TypeInt,
 			Description: "The apiserver listening port",
 
+			Computed: true,
+
 			Optional: true,
 			ForceNew: true,
-
-			Default: 8443,
 		},
 
 		"auto_pause_interval": {
@@ -817,10 +817,10 @@ var (
 			Type:        schema.TypeString,
 			Description: "network to run minikube with. Used by docker/podman, qemu, kvm, and vfkit drivers. If left empty, minikube will create a new network.",
 
+			Computed: true,
+
 			Optional: true,
 			ForceNew: true,
-
-			Default: "",
 		},
 
 		"nfs_share": {


### PR DESCRIPTION
## What

A second `terraform apply` against a qemu2 cluster destroyed and recreated it:

```
  # minikube_cluster.this must be replaced
-/+ resource "minikube_cluster" "this" {
      ~ apiserver_port = 33665 -> 8443 # forces replacement
      - network        = "builtin" -> null # forces replacement
      ~ host           = "https://localhost:33665" -> (known after apply)
    }

Plan: 1 to add, 0 to change, 1 to destroy.
```

`apiserver_port` and `network` carried schema defaults (`8443` and `""`) that minikube overrides with its own values, and `setClusterState` writes those back into state. Both are `ForceNew`, so every subsequent plan saw a diff it could only resolve by replacing the cluster.

## Why the defaults can never match

Neither value is something a practitioner can pin for qemu2:

- **`apiserver_port`** — minikube allocates a *fresh random free host port* for the QEMU builtin network on every start, in `node.startMachine`:
  ```go
  if driver.IsQEMU(hostInfo.Driver.DriverName()) && network.IsBuiltinQEMU(cfg.Network) {
      apiServerPort, err := getPort()
      ...
      cfg.APIServerPort = apiServerPort
  }
  ```
- **`network`** — minikube resolves an unset network per driver, to `"builtin"` or `"socket_vmnet"` (`validateQemuNetwork`). The provider's own `resolveNetwork` already normalises `""` to `"builtin"` for QEMU, so the value written back was guaranteed to differ from the schema default.

The docker driver was unaffected because its apiserver really does listen on 8443.

## The change

Make both `Optional+Computed` rather than defaulted — the idiomatic shape for an attribute a practitioner *may* request but the provider otherwise decides. An unset attribute now accepts whatever the cluster reports instead of fighting it; an explicitly configured value still forces replacement when it changes.

Supporting changes:

- The SDK rejects a schema carrying both `Default` and `Computed`, so the generator no longer emits a `Default` for computed fields. Every previously computed field was a set, which never had one, so the generated schema changes **only** for these two attributes.
- `apiserver_port` no longer has a schema default, so an unset value reads back as zero. `resolveAPIServerPort` supplies minikube's own `constants.APIServerPort` in that case, mirroring the existing `resolveNetwork`.

`schema_cluster.go` is regenerated rather than hand-edited, so `make schema` stays reproducible. The regenerated diff is exactly the four lines you would expect.

Generated docs are unchanged: `Optional+Computed` renders under **Optional** just like the existing `apiserver_names`.

## Testing

- `go test -tags libvirt_dlopen ./...` passes. `TestProvider` exercises `InternalValidate()`, which is what would catch an invalid Default+Computed schema.
- New `TestResolveAPIServerPort` covers unset, explicit and driver-assigned ports.
- `TestComputedProperty` in the generator now asserts a computed field emits no `Default`.
- `getBaseMockClient` derived its expectation from `clusterSchema[...].Default`; it now calls the resolvers, so the test tracks production logic rather than duplicating a constant.
- End to end against real clusters with the e2e suite (#269): **qemu goes from 1 failed to 21 passed / 0 failed / 1 skip**, with "terraform plan is clean after apply" now passing. **Docker stays at 22/22**, confirming no regression from the schema change.

> Note: verifying the full qemu apply → plan → destroy cycle also needs #268, without which the destroy segfaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
